### PR TITLE
Web App Icon and Title added (again)

### DIFF
--- a/TeslaLogger/www/admin/index.php
+++ b/TeslaLogger/www/admin/index.php
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="apple-mobile-web-app-title" content="Teslalogger Config">
+    <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
     <title>Teslalogger Config V1.5</title>
 	<link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
 	<link rel="stylesheet" href="http://teslalogger.de/teslalogger_style.css">


### PR DESCRIPTION
Die beiden Metadata-Einträge für das Web App Icon und den Title waren in einem der Pull-Requests (#21) bereits enthalten und wurden auch übernommen. Mit der neusten Änderung sind die beiden Einträge wieder verschwunden. Versehen, oder Absicht?

Mit der vorgeschlagenen Änderung kann man einen Link auf die Config-Seite als iOS-App mit passendem Icon auf dem Homescreen von iOS-Geräten speichern. Auf Nicht-iOS-Geräten werden die Metadata-Einträge ignoriert.