### PR TITLE
Make all links in admin page relative

### DIFF
--- a/TeslaLogger/www/admin/index.php
+++ b/TeslaLogger/www/admin/index.php
@@ -104,7 +104,7 @@
   <button onclick="BackgroudRun('update.php', 'Reboot!');">Update</button>
   <button onclick="window.location.href='backup.php';">Backup</button>
   <button onclick="window.location.href='geofencing.php';">Geofence</button>
-  <button onclick="BackgroudRun('/wakeup.php', 'Wakeup!');">Wakeup</button>
+  <button onclick="BackgroudRun('wakeup.php', 'Wakeup!');">Wakeup</button>
   <button onclick="BackgroudRun('gosleep.php', 'Sleep!');">Sleep</button>
   <button onclick="window.location.href='settings.php';">Settings</button>
   


### PR DESCRIPTION
Make all links in admin page relative so the admin page can be served under an alternative path (e.g. reverse proxy). Here's an example config for an nginx reverse proxy:

```
server {
  listen 443 ssl http2;
  listen [::]:443 ssl http2;
  server_name teslalogger.example.com;

  ssl_certificate /etc/dehydrated/certs/teslalogger.example.com/fullchain.pem;
  ssl_certificate_key /etc/dehydrated/certs/teslalogger.example.com/privkey.pem;

  location /admin {
    # don't forget to create a password file with htpasswd
    auth_basic "Admin only";
    auth_basic_user_file /etc/teslalogger/.htpasswd;
    proxy_pass http://127.0.0.1/admin/;
  }

  location / {
    proxy_pass http://127.0.0.1:3000/;
  }
}
```