### PR TITLE
Geofence.csv, CH-Kriegstetten

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -323,7 +323,7 @@ Supercharger CH-Dietikon, 47.418041, 8.396577
 Supercharger CH-Dietlikon, 47.4129254, 8.6178231
 Supercharger CH-Egerkingen, 47.327028, 7.805489
 Supercharger CH-Flüelen, 46.912985, 8.622833
-Supercharger CH-Kriegstetten, 47.1753676, 7.5967831
+Supercharger CH-Kriegstetten, 47.175635, 7.59883
 Supercharger CH-Lully, 46.8323911, 6.8590898
 Supercharger CH-Maienfeld, 47.003965, 9.525809
 Supercharger CH-Martigny, 46.126409, 7.061010


### PR DESCRIPTION
Updated the GPS data from a charging session on site. TeslaLogger was showing not the SuC name but the address