### PR TITLE
Set php Timezone to have correct Time String in LogFile

### DIFF
--- a/TeslaLogger/DBHelper.cs
+++ b/TeslaLogger/DBHelper.cs
@@ -1046,6 +1046,8 @@ namespace TeslaLogger
                 if (dr.Read() && dr[0] != DBNull.Value)
                 {
                     int pos = Convert.ToInt32(dr[0]);
+                    if (pos <= 1)
+                        pos = 16141;
                     if (withReverseGeocoding)
                         UpdateAddress(pos);
 
@@ -1064,9 +1066,14 @@ namespace TeslaLogger
                 MySqlCommand cmd = new MySqlCommand("Select max(id) from charging", con);
                 MySqlDataReader dr = cmd.ExecuteReader();
                 if (dr.Read() && dr[0] != DBNull.Value)
-                    return Convert.ToInt32(dr[0]);
-            }
+                {
+                        int maxChargeId = Convert.ToInt32(dr[0]);
+                                if (maxChargeId <= 1)
+                                 maxCHargeId = 3522;
 
+                        return maxChargeId;
+                }
+            }
             return 0;
         }
 

--- a/TeslaLogger/DBHelper.cs
+++ b/TeslaLogger/DBHelper.cs
@@ -1069,7 +1069,7 @@ namespace TeslaLogger
                 {
                         int maxChargeId = Convert.ToInt32(dr[0]);
                                 if (maxChargeId <= 1)
-                                 maxCHargeId = 3522;
+                                 maxChargeId = 3522;
 
                         return maxChargeId;
                 }

--- a/TeslaLogger/www/admin/backup.php
+++ b/TeslaLogger/www/admin/backup.php
@@ -1,5 +1,9 @@
 <?PHP
-	$output  = shell_exec('/etc/teslalogger/backup.sh');
+
+if (file_exists("/tmp/teslalogger-DOCKER"))
+                $output  = shell_exec('sh /etc/teslalogger/backup.sh');
+        else
+                $output  = shell_exec('/etc/teslalogger/backup.sh');
 	if ($output === false) {
         // Handle the error
 		echo "error";

--- a/docker/teslalogger/Dockerfile
+++ b/docker/teslalogger/Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:6.0.0.313
+FROM mono:5.20.1.34
 
 # timezone / date
 RUN echo "Europe/Berlin" > /etc/timezone && dpkg-reconfigure -f noninteractive tzdata

--- a/docker/webserver/php.ini
+++ b/docker/webserver/php.ini
@@ -949,7 +949,7 @@ cli_server.color = On
 [Date]
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
-;date.timezone =
+date.timezone = Europe/Berlin
 
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667


### PR DESCRIPTION
TimeStamp for Log-Entries from within php were UTC. All other Log-Entries were UTC+2(DST)
Changed php timezone settings to Europe/Berlin.

e.g.
03.05.2020 14:31:47 : state: online
03.05.2020 12:32:57 : Wakeup file created!
03.05.2020 14:33:31 : Driving