### PR TITLE
Bugfix mothership commands

### DIFF
--- a/TeslaLogger/DBHelper.cs
+++ b/TeslaLogger/DBHelper.cs
@@ -24,6 +24,7 @@ namespace TeslaLogger
 
         public static void EnableMothership()
         {
+            GetMothershipCommandsFromDB();
             mothershipEnabled = true;
         }
 


### PR DESCRIPTION
this fixes that the first command to be inserted is always inserted into the db into mothershipcommands although it is already there