### PR TITLE
Implemented Certificate Trust Store Refresh

### DIFF
--- a/TeslaLogger/UpdateTeslalogger.cs
+++ b/TeslaLogger/UpdateTeslalogger.cs
@@ -210,6 +210,7 @@ namespace TeslaLogger
 
                     Exec_mono("rm", "-rf /etc/teslalogger/git");
                     Exec_mono("mkdir", "/etc/teslalogger/git");
+                    Exec_mono("mozroots", "--import --sync --machine");
                     Exec_mono("git", "clone --progress https://github.com/bassmaster187/TeslaLogger /etc/teslalogger/git/", true, true);
 
                     Tools.CopyFilesRecursively(new DirectoryInfo("/etc/teslalogger/git/TeslaLogger/GrafanaPlugins"), new DirectoryInfo("/var/lib/grafana/plugins"));


### PR DESCRIPTION
Before performing git clone during Update the Machine Trust Store ist synchronized to Mozilla Root CAs. This ensures updates are working on newer versions of Debian such as "stretch".