### PR TITLE
Update geofence.csv

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -1042,7 +1042,7 @@ Tesla Service Center FR-Paris, 48.8699445, 2.3208625
 Tesla Service Center IT-Milano, 45.4287001, 9.3236095
 Tesla Service Center IT-Padua, 45.3892437, 11.9484972
 Tesla Service Center LU-Luxembourg, 49.5897262, 6.1390134
-Tesla Service Center NL-Arnhem, 51.9650593, 6.0015653
+Tesla Service Center NL-Arnhem, 51.965004, 6.003759
 Tesla Service Center NL-Den Haag, 52.0704378, 4.3883438
 Tesla Service Center NL-Groningen, 53.2230636, 6.6094115
 Tesla Service Center NL-Rotterdam, 51.8648704, 4.4548565


### PR DESCRIPTION
Koordinaten SeC Arnheim korrigiert. Ist im aktuellen geofence.csv offenbar bei Hausnummer 22 angesiedelt, das SeC ist aber bei Hausnummer 32. War gestern dort ;-) 