### PR TITLE
BF translation

### DIFF
--- a/TeslaLogger/UpdateTeslalogger.cs
+++ b/TeslaLogger/UpdateTeslalogger.cs
@@ -1079,7 +1079,7 @@ CREATE TABLE superchargerstate(
                             {
                                 s = ReplaceTitleTag(s, "Degradation", dictLanguage);
                                 s = ReplaceLanguageTags(s, new string[] {
-                                    "Maximalreichweite[km]", "Maximalreichweite [mi]","mi Stand [mi]","km Stand [km]","Max. Reichweite (Monatsmittel) [km]","Max. Reichweite (Monatsmittel) [mi]"
+                                    "Maximalreichweite [km]", "Maximalreichweite [mi]","mi Stand [mi]","km Stand [km]","Max. Reichweite (Monatsmittel) [km]","Max. Reichweite (Monatsmittel) [mi]"
                                 }, dictLanguage, true);
                             }
                             else if (f.EndsWith("Firmware.json"))


### PR DESCRIPTION
"Maximalreichweite [km]" vs "Maximalreichweite[km]"
Reason: Key 'Maximalreichweite[km]' not Found in Translationfile!