### PR TITLE
Please ignore/reject this PR: was: Install cron & rclone as default in teslalogger image

### DIFF
--- a/TeslaLogger/UpdateTeslalogger.cs
+++ b/TeslaLogger/UpdateTeslalogger.cs
@@ -662,6 +662,25 @@ CREATE TABLE superchargerstate(
                     Logfile.Log("append backup.sh to crontab!");
                     File.AppendAllText(crontab, "0 1 * * * root /bin/bash /etc/teslalogger/backup.sh\n");
                 }
+
+                else if (Tools.IsDocker())
+                {
+                    Logfile.Log("DOCKER: check crontab!");
+
+                    string crontab = "/etc/crontab";
+
+                    if (!File.Exists(crontab))
+                    {
+                        Logfile.Log("DOCKER: It seems that there is no cron installed in your Teslalogger Docker Container - please recreate the container!");
+                        return;
+                    }
+
+                    if (File.ReadAllText(crontab).Contains("/etc/teslalogger/backup.sh"))
+                        return;
+
+                    Logfile.Log("DOCKER: append backup.sh to crontab!");
+                    File.AppendAllText(crontab, "0 1 * * * root /bin/bash /etc/teslalogger/backup.sh\n");
+                }
             }
             catch (Exception ex)
             {

--- a/docker/teslalogger/Dockerfile
+++ b/docker/teslalogger/Dockerfile
@@ -7,6 +7,8 @@ RUN echo "Europe/Berlin" > /etc/timezone && dpkg-reconfigure -f noninteractive t
 RUN apt-get update && \
   apt-get install -y --no-install-recommends git && \
   apt-get install -y --no-install-recommends mariadb-client && \
+  apt-get install -y --no-install-recommends cron && \
+  apt-get install -y --no-install-recommends rclone && \
   apt-get clean && \
   apt-get autoremove -y && \
   rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
...and add backup.sh to /etc/crontab if not existing

So automatic backup works in Docker.

To test you obviously need to recreate the image.

Based on the valid [remark in TFF](https://tff-forum.de/t/teslalogger-mit-raspberry-pi-mysql-grafana-osm/100891/834)  - please ignore/reject this PR