### PR TITLE
Log mothership request timeout

### DIFF
--- a/TeslaLogger/WebHelper.cs
+++ b/TeslaLogger/WebHelper.cs
@@ -3273,7 +3273,7 @@ namespace TeslaLogger
                 {
                     DBHelper.AddMothershipDataToDB("GetCommand(" + cmd + ")", -1, (int)result.StatusCode);
                     Log("Result.Statuscode: " + (int)result.StatusCode + " (" + result.StatusCode.ToString() + ") cmd: " + cmd);
-                    Thread.Sleep(30000);
+                    Thread.Sleep(5000);
                 }
                 else
                 {

--- a/TeslaLogger/WebHelper.cs
+++ b/TeslaLogger/WebHelper.cs
@@ -3264,6 +3264,7 @@ namespace TeslaLogger
                 }
                 else if (result.StatusCode == HttpStatusCode.RequestTimeout)
                 {
+                    DBHelper.AddMothershipDataToDB("GetCommand(" + cmd + ")", -1, (int)result.StatusCode);
                     Log("Result.Statuscode: " + (int)result.StatusCode + " (" + result.StatusCode.ToString() + ") cmd: " + cmd);
                     Thread.Sleep(30000);
                 }

--- a/TeslaLogger/WebHelper.cs
+++ b/TeslaLogger/WebHelper.cs
@@ -1469,7 +1469,14 @@ namespace TeslaLogger
 
                 resultContent = await result.Content.ReadAsStringAsync();
                 _ = car.GetTeslaAPIState().ParseAPI(resultContent, "vehicles", car.CarInAccount);
-                DBHelper.AddMothershipDataToDB("IsOnline()", start, (int)result.StatusCode);
+                if (result.IsSuccessStatusCode)
+                {
+                    DBHelper.AddMothershipDataToDB("IsOnline()", start, (int)result.StatusCode);
+                }
+                else
+                {
+                    DBHelper.AddMothershipDataToDB("IsOnline()", -1, (int)result.StatusCode);
+                }
                 if (TeslaAPI_Commands.ContainsKey("vehicles"))
                 {
                     TeslaAPI_Commands.TryGetValue("vehicles", out string drive_state);


### PR DESCRIPTION
Mothership Dashboard bitte anpassen:

SELECT
  $__time(ts),
  duration as value,
  concat(command,'_',httpcode) as metric