### PR TITLE
Two small dashboard fixes: DC on Ladestatistik and Link to Start Adresse on Ladehistorie

### DIFF
--- a/TeslaLogger/Grafana/Ladestatistik.json
+++ b/TeslaLogger/Grafana/Ladestatistik.json
@@ -1019,7 +1019,7 @@
         "ymax": null,
         "ymin": null
       },
-      "tableColumn": "sum(charging_End.charge_energy_added)",
+      "tableColumn": "",
       "targets": [
         {
           "format": "table",

--- a/TeslaLogger/Grafana/Trip.json
+++ b/TeslaLogger/Grafana/Trip.json
@@ -266,7 +266,7 @@
                   {
                     "targetBlank": true,
                     "title": "Add Geofence ",
-                    "url": "http://raspberry/admin/geoadd.php?lat=${__cell_0}&lng=${__cell_1}"
+                    "url": "http://raspberry/admin/geoadd.php?lat=${__data.fields.lat}&lng=${__data.fields.lng}"
                   }
                 ]
               },


### PR DESCRIPTION
This contains two fixes to the grafana dashboards:

- DC on Ladestatistik fixed (was just "N/A")
- Link to Start Adresse on Ladehistorie didn't fill in the lat/lng