### PR TITLE
fix mono dependency issue "E: The method driver /usr/lib/apt/methods/https could not be found."

### DIFF
--- a/docker/teslalogger/Dockerfile
+++ b/docker/teslalogger/Dockerfile
@@ -1,4 +1,4 @@
-FROM mono:5.20.1.34
+FROM mono:6.10.0.104
 
 # timezone / date
 RUN echo "Europe/Berlin" > /etc/timezone && dpkg-reconfigure -f noninteractive tzdata


### PR DESCRIPTION
when trying to build the application from scratch with docker-compose it fails with the below error message.
With the new mono version it works. Tested on a raspberry pi 4 with Raspberry Pi OS

E: The method driver /usr/lib/apt/methods/https could not be found.

ERROR: Service 'teslalogger' failed to build: The command '/bin/sh -c apt-get update &&   apt-get install -y --no-install-recommends git &&   apt-get install -y --no-install-recommends mariadb-client &&   apt-get clean &&   apt-get autoremove -y &&   rm -rf /var/lib/apt/lists/* &&   echo "export TERM=xterm" >> /root/.bashrc  &&   echo "DOCKER" >> /tmp/teslalogger-DOCKER' returned a non-zero code: 100