### PR TITLE
Revert "Update geofence.csv"

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -2223,7 +2223,6 @@ Lidl FI-Vantaa, 60.261581, 24.87252
 Lidl IT-Peschiera del Garda, 45.43475, 10.680242
 Lidl SE-Falkenberg, 56.91611,12.502524
 
-Mainova DE-Frankfurt am Main Oeder Weg 43, 50.121117,8.680242,8
 Mainova DE-Frankfurt am Main Parkhaus Börse, 50.115389, 8.675916
 
 MOL CZ-Bělčice, 49.840839,14.813349


### PR DESCRIPTION
Reverts bassmaster187/TeslaLogger#790

Beide Mainova Stationen sind AC, somit nicht für´s öffentliche Geofencing 