### PR TITLE
Buttonwillow is in fact Bakersfield

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -840,7 +840,7 @@ Supercharger-V3 US-Brighton CO, 39.971947, -104.74852
 Supercharger US-Bristol TN, 36.591663, -82.261292
 Supercharger-V3 US-Brunswick GA,31.246021,-81.501863
 Supercharger US-Buford GA, 34.061649, -83.994602
-Supercharger US-Buttonwillow CA,35.354621,-119.33163
+Supercharger US-Bakersfield CA,35.354621,-119.33163
 Supercharger US-Burleson TX, 32.464365,-97.26451
 Supercharger-V3 US-Burley ID,42.561592,-113.790105
 Supercharger-V3 US-Bolingbrook IL, 41.722252, -88.037124


### PR DESCRIPTION
Search for this coordinates will find the Bakersfield supercharger: https://www.google.de/maps/place/35%C2%B021'16.6%22N+119%C2%B019'53.9%22W/@35.354621,-119.333824,17z/data=!3m1!4b1!4m5!3m4!1s0x0:0xbc7552e791ac419c!8m2!3d35.354621!4d-119.33163