### PR TITLE
Update geofence.csv

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -289,6 +289,7 @@ Supercharger-V3 DE-Vaterstetten, 48.146719,11.790205
 Supercharger-V3 DE-Vaterstetten, 48.146472,11.790255
 Supercharger-V3 DE-Vaterstetten, 48.146213,11.790329
 Supercharger DE-Waldlaubersheim, 49.9240135, 7.825654
+Supercharger-V3 DE-Weibersbrunn, 49.934777,9.353755
 Supercharger DE-Weimar, 50.9342158, 11.289809
 Supercharger-V3 DE-Weiterstadt, 49.89679,8.614198
 Supercharger-V3 DE-Wernberg-Köblitz, 49.532249, 12.134949, 8
@@ -297,8 +298,8 @@ Supercharger-V3 DE-Wernberg-Köblitz, 49.532255,12.135223, 7
 Supercharger DE-Wernberg-Köblitz, 49.532249, 12.134949, 8
 Supercharger DE-Wernberg-Köblitz, 49.53225, 12.1351, 7
 Supercharger DE-Wernberg-Köblitz, 49.532255,12.135223, 7
-Supercharger-V3 DE-Weibersbrunn, 49.934777,9.353755
 Supercharger DE-Wertheim, 49.770559, 9.576456
+Supercharger-V3 DE-Wetzlar, 50.552762, 8.532845, 30
 Supercharger DE-Weyarn, 47.865307, 11.790695
 Supercharger DE-Wiesbaden, 50.0598477, 8.3451326
 Supercharger DE-Wilnsdorf, 50.8168944, 8.085813
@@ -2411,7 +2412,7 @@ DE Schafstritt Nord, 52.257481, 9.306448
 DE Schönefeld Total, 52.370738, 13.526929
 DE Sandersdorf-Brehna The Style Outlets, 51.555325, 12.192875
 DE Stuttgart Flughafen P12, 48.691895, 9.195894
-DE Wetzlar Leica, 50.553084, 8.533377
+DE Wetzlar Leica, 50.553084, 8.533377, 20
 ES Gandia, 38.969986, -0.178789
 FR 68510 Sierentz Hyper U et Drive, 47.666180, 7.441494, 10
 IT Vahrn Mautstation Casello Bressanone-Val Pusteria, 46.763952, 11.6430823, 20


### PR DESCRIPTION
Adding verified (by Mittelhesse) Tesla Supercharger V3.0 for following location 
Am Leitz-Park 4, 35578 Wetzlar, DE
   Supercharger-V3 DE-Wetzlar, 50.552762, 8.532845, 30
Adding a geofence of 30m for that location, since there is a 2nd position for a charger of enwag
   DE Wetzlar Leica, 50.553084, 8.533377, 20
Adding a geofence of 20m for existing entry at this address, slightly different coordinates.
Moved Supercharger-V3 DE-Weibersbrunn, 49.934777,9.353755 from line 300 to line 292 (correct lexical order)

location on open maps
![grafik](https://user-images.githubusercontent.com/108473979/176700459-7cc1a292-e6b3-4841-b90d-099237dd656b.png)

location verified (the "Cringle") with Stefan Becker (Mittelhesse): 
![grafik](https://user-images.githubusercontent.com/108473979/176700691-e516ad3a-9430-4955-9139-d2a63b30ea94.png)
