### PR TITLE
Korrektur fuer Barcelona

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -342,7 +342,7 @@ Supercharger ES-Almaraz, 39.791255, -5.695668
 Supercharger ES-Aranda de Duero, 41.623235, -3.687739
 Supercharger ES-Ariza, 41.313192, -2.002201
 Supercharger ES-Atalaya del Cañavate, 39.538687, -2.254555
-Supercharger ES-Barcelona, 41.498135, 2.072674
+Supercharger ES-Barcelona-L'Illa Diagonal, 41.389679,2.137354
 Supercharger ES-Bembibre, 42.623488,-6.453124
 Supercharger-V3 ES-Benavente, 42.007749,-5.663257
 Supercharger ES-Burgos, 42.312365, -3.704115


### PR DESCRIPTION
Es gibt im moment 2 Supercharger um Barcelona, L'Illa Diagonal und ausserhalb in Sant Cugat.

Die Koordinaten von Barcelona waren die von Sant Cugat die auch schon in der Liste sind. Daher habe ich Barcelona korrigiert mit dem richtigen Namen und die Koordinaten angepasst.