### PR TITLE
SC V3 CH Pfäffikon und St. Gallen hinzugefügt.

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -123,10 +123,12 @@ Supercharger CH-Melide, 45.95423, 8.95051
 Supercharger CH-Monte Ceneri, 46.13924, 8.9070614
 Supercharger-V3 CH-Obfelden, 47.272009,8.437787, 26
 Supercharger CH-Oftringen, 47.310793,7.935012
+Supercharger-V3 CH-Pfäffikon SZ, 47.199915, 8.794428
 Supercharger CH-Pratteln, 47.524711,7.680202
 Supercharger CH-Quinto, 46.51521, 8.67063
 Supercharger CH-Rubigen, 46.891773, 7.542738
 Supercharger CH-Schaffhausen, 47.720985, 8.646664
+Supercharger-V3 CH-St. Gallen, 47.408150, 9.304028
 Supercharger CH-St. Moritz, 46.496797, 9.84272
 Supercharger CH-Steg-Hohtenn, 46.310364, 7.749565
 Supercharger CN-DoubleTree by Hilton Hotel Guangzhou Huihua, 23.183827,113.470749


### PR DESCRIPTION
Ich hab' das mal versucht offiziell per Github einzutüten. Mal schauen ob das klappt.
Bei den Koordinaten war ich nicht sicher, welche ich nehmen muss. Habe mich per Google Maps an die Koordinaten vom offiziellen Tesla Eintrag angenähert. Bei St. Gallen stimmten diese nicht ganz überein mit den Koordinaten, welche TL für mich geloggt hatte. Da der Supercharger unterirdisch im Parkhaus ist, steht der Google Eintrag ziemlich weit vorne beim Eingang. Effektiv sind die SC aber weiter innen.
Bei mir in meiner Docker Installation kommen die Einträge in der Ladehistorie jetzt korrekt.