### PR TITLE
Prevent double-slashes in Grafana URL on Journeys

### DIFF
--- a/TeslaLogger/www/admin/journeys.php
+++ b/TeslaLogger/www/admin/journeys.php
@@ -353,7 +353,8 @@ select.newJourney {width: 500px;}
         var uend = end.getTime();
         var temp = "<a href='";
         temp += url_grafana;
-        temp += "/d/";
+        temp += temp.endsWith("/") ? "" : "/";
+        temp += "d/";
         temp += uid;
         temp += "/dashboard?orgId=1&from=";
         temp += ustart +"&to="+ uend +"&var-Car="+carid+ parameters+ "' target=\"_blank\">";


### PR DESCRIPTION
Currently, when the Grafana URL ends with a slash, then all Grafana links on the Journeys page contain two slashes `...//d/...` and are invalid.

This PR fixes the issue by making sure only a single slash is added in either case.