### PR TITLE
Show logo via favicon link tag

### DIFF
--- a/TeslaLogger/www/admin/dashboard.php
+++ b/TeslaLogger/www/admin/dashboard.php
@@ -21,6 +21,7 @@ else
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="apple-mobile-web-app-title" content="Teslalogger Dashboard">
 	<link href="manifest.json" rel="manifest" crossorigin="use-credentials">
+	<link rel="icon" type="image/png" href="img/apple-touch-icon.png">
     <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
     <title>Teslalogger Dashboard</title>
 	<link rel="stylesheet" href="dashboard.css?v=<?=time()?>" />

--- a/TeslaLogger/www/admin/index.php
+++ b/TeslaLogger/www/admin/index.php
@@ -22,6 +22,7 @@ else
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-title" content="Teslalogger Config">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<link rel="icon" type="image/png" href="img/apple-touch-icon.png">
     <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
     <title>Teslalogger</title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">


### PR DESCRIPTION
When opening TeslaLogger on a Chrome browser on a desktop PC or an Android device, it doesn't show the TeslaLogger logo on the tab.

As a fix, this PR copies the link tag for iOS devices (`rel="apple-touch-icon"`) and adds one for other browsers (`rel="icon"`)