### PR TITLE
Update geofence.csv

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -161,6 +161,7 @@ Supercharger-V3 DE-Bissendorf,52.238354,8.162975
 Supercharger DE-Blankenfelde-Mahlow, 52.3089548, 13.444767
 Supercharger-V3 DE-Blankenfelde-Mahlow, 52.308865, 13.443957, 25
 Supercharger-V3 DE-Bochum - Ruhr Park, 51.49506,7.28483
+Supercharger-V3 DE-Bonn - Bonner Bogen, 50.718553, 7.152138 
 Supercharger-V3 DE-Böblingen,48.69138,9.003647
 Supercharger-V3 DE-Braak, 53.6178758, 10.239352
 Supercharger DE-Braak, 53.6178758, 10.239352
@@ -183,8 +184,10 @@ Supercharger-V3 DE-Erharting, 48.282664, 12.554758
 Supercharger-V3 DE-Eschborn, 50.133770, 8.561050
 Supercharger-V3 DE-Frechen, 50.917843, 6.83323183, 20
 Supercharger-V3 DE-Feucht, 49.36501,11.20753
+Supercharger-V3 DE-Füssen, 47.567924, 10.675875, 18
 Supercharger DE-Geiselwind, 49.769178, 10.470429, 15
 Supercharger-V3 DE-Geiselwind 49.769544, 10.470236, 30
+Supercharger-V3 DE-Geiselwind 49.769512, 10.470241, 30
 Supercharger-V3 DE-Gelnhausen,50.188644,9.186141
 Supercharger-V3 DE-Gensingen, 49.90202, 7.929759
 Supercharger DE-Gensingen, 49.90202, 7.929759


### PR DESCRIPTION
SuC Füssen und Bonn neu eingetragen.
SuC Geiselwind ergänzt, da die ersten Stalls mit dem ursprünglichen Eintrag nicht im Teslalogger als Suc erkannt wurden