### PR TITLE
Added missing superchargers and ENBW DE-Kriftel to geofence.csv

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -380,7 +380,9 @@ Supercharger-V3 DE-Wuppertal, 51.282478, 7.256275
 Supercharger-V3 DE-Wuppertal, 51.282426, 7.256019
 Supercharger DE-Zella-Mehlis, 50.64387, 10.68488
 Supercharger-V3 DE-Zusmarshausen, 48.407771,10.599446, 25
+Supercharger-V3 DK-Aalborg, 57.004005, 9.870825
 Supercharger DK-Aarhus, 56.178223, 10.139406
+Supercharger-V3 DK-Copenhagen North, 55.772665, 12.504799
 Supercharger-V3 DK-Esbjerg, 55.465749, 8.44405, 25
 Supercharger DK-Haverslev, 56.783428, 9.69082
 Supercharger DK-Hedensted, 55.786395, 9.667926
@@ -393,6 +395,8 @@ Supercharger DK-Køge, 55.489014, 12.163153
 Supercharger-V3 DK-Maribo, 54.779188, 11.477063, 40
 Supercharger DK-Middelfart, 55.511311, 9.765029
 Supercharger DK-Nørre Alslev, 54.899872, 11.896921
+Supercharger-V3 DK-Nykøbing Mors, 56.788618, 8.828769
+Supercharger-V3 DK-Odense, 55.384464, 10.427848
 Supercharger DK-Randers, 56.433685, 10.055412
 Supercharger DK-Rødekro, 55.067331, 9.361081, 20
 Supercharger DK-Rødekro, 55.068085, 9.360869, 20

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -318,6 +318,7 @@ Supercharger-V3 DE-Rhüden,51.947298,10.140858,6
 Supercharger-V3 DE-Rhüden,51.947243,10.140858,6
 Supercharger DE-Rhüden, 51.947221, 10.140505, 12
 Supercharger-V3 DE-Rosenheim,47.817007,12.120582
+Supercharger-V3 DE-Rüsselsheim,49.968394,8.390394
 Supercharger DE-Sangerhausen, 51.450551, 11.3044818
 Supercharger-V3 DE-Satteldorf, 49.18119, 10.06933
 Supercharger DE-Satteldorf, 49.18119, 10.06933

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -156,7 +156,9 @@ Supercharger-V3 DE-Augsburg,48.398906,10.868047,30
 Supercharger-V3 DE-Augsburg,48.398938,10.868306,30
 Supercharger-V3 DE-Bad Oeynhausen,52.213278,8.814397
 Supercharger DE-Bad Rappenau, 49.21198, 9.07726
+Supercharger-V3 DE-Baden-Baden, 48.78364, 8.19225
 Supercharger DE-Beelitz, 52.266803, 12.922467
+Supercharger-V3 DE-Berchtesgaden, 47.626649, 13.000651
 Supercharger-V3 DE-Bergkamen,51.649452,7.671108,20
 Supercharger-V3 DE-Bensheim, 49.672353, 8.6022525, 22
 Supercharger-V3 DE-Berlin - EUREF-Campus, 52.4808984, 13.3558539
@@ -172,6 +174,7 @@ Supercharger-V3 DE-Bonn - Bonner Bogen, 50.718553, 7.152138
 Supercharger-V3 DE-Böblingen,48.69138,9.003647
 Supercharger-V3 DE-Braak, 53.6178758, 10.239352
 Supercharger DE-Braak, 53.6178758, 10.239352
+Supercharger-V3 DE-Burgdorf, 52.122814, 10.228904
 Supercharger DE-Busdorf, 54.477896, 9.544913								   
 Supercharger DE-Brinkum, 53.028326, 8.808758
 Supercharger DE-Bruchsal, 49.13837, 8.56242
@@ -207,7 +210,9 @@ Supercharger DE-Gützkow, 53.943943, 13.396739
 Supercharger DE-Hamburg, 53.460881, 9.940546
 Supercharger-V3 DE-Hamburg - Stillhorn, 53.479701, 10.025150
 Supercharger-V3 DE-Hamburg-Wandsbek, 53.586773, 10.098058
+Supercharger-V3 DE-Hanau, 50.105195, 8.916918
 Supercharger-V3 DE-Hannover, 52.423275,9.835039, 20
+Supercharger-V3 DE-Heede, 52.985372, 7.248233
 Supercharger-V3 DE-Hemsbach, 49.594071, 8.632455, 30
 Supercharger DE-Hengersberg, 48.76555, 13.04668
 Supercharger DE-Herboltzheim, 48.22704, 7.75368
@@ -231,6 +236,7 @@ Supercharger DE-Hilpoltstein,49.161213,11.260555,8
 Supercharger DE-Hilpoltstein,49.161201,11.260685,12
 Supercharger DE-Hirschberg, 49.50738, 8.63752
 Supercharger DE-Hohenwarsleben, 52.174053, 11.494502, 15
+Supercharger-V3 DE-Holzkirchen, 47.8810757, 11.70275368
 Supercharger DE-Irschenberg, 47.82648, 11.89831
 Supercharger-V3 DE-Irschenberg, 47.826678, 11.898501
 Supercharger-V3 DE-Irxleben, 52.170617, 11.484912
@@ -318,7 +324,7 @@ Supercharger-V3 DE-Rhüden,51.947298,10.140858,6
 Supercharger-V3 DE-Rhüden,51.947243,10.140858,6
 Supercharger DE-Rhüden, 51.947221, 10.140505, 12
 Supercharger-V3 DE-Rosenheim,47.817007,12.120582
-Supercharger-V3 DE-Rüsselsheim,49.968394,8.390394
+Supercharger-V3 DE-Rüsselsheim,49.968408, 8.390534
 Supercharger DE-Sangerhausen, 51.450551, 11.3044818
 Supercharger-V3 DE-Satteldorf, 49.18119, 10.06933
 Supercharger DE-Satteldorf, 49.18119, 10.06933
@@ -329,6 +335,7 @@ Supercharger-V3 DE-Schleiz,50.54647989730031,11.803035300128926,20
 Supercharger DE-Schweitenkirchen, 48.510765, 11.582025, 19
 Supercharger-V3 DE-Sindelsdorf, 47.728372, 11.361923
 Supercharger DE-Sindelsdorf, 47.728372, 11.361923
+Supercharger-V3 DE-Solingen, 51.129579, 6.995592
 Supercharger-V3 DE-Soltau-Ost,52.983332,9.925548
 Supercharger DE-Stuhr (Bremen-Brinkum), 53.0284305, 8.8061246
 Supercharger DE-Sulz-Vöhringen, 48.34305, 8.66262, 30
@@ -344,6 +351,7 @@ Supercharger-V3 DE-Vaterstetten, 48.146719,11.790205
 Supercharger-V3 DE-Vaterstetten, 48.146472,11.790255
 Supercharger-V3 DE-Vaterstetten, 48.146213,11.790329
 Supercharger-V3 DE-Viernheim - Rhein-Neckar-Zentrum,49.528083,8.565772,30
+Supercharger-V3 DE-Waiblingen, 48.82149836, 9.29680224
 Supercharger DE-Waldlaubersheim, 49.9240135, 7.825654
 Supercharger-V3 DE-Weibersbrunn, 49.934777,9.353755
 Supercharger DE-Weimar, 50.9342158, 11.289809

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -1609,6 +1609,7 @@ EnBW DE-Kirchheim Trigema, 50.832535,9.573169, 10
 EnBW DE-Koblenz Autohof Rübenacher Wald, 50.347123, 7.507522
 EnBW DE-Kraftsdorf, 50.8955874, 11.9809509
 EnBW DE-Kraichgau Süd, 49.240896, 8.879563, 20
+EnBW DE-Kriftel, 50.0766042, 8.4721672, 30
 EnBW DE-Lonetal Ost, 48.58408, 10.17877, 6
 EnBW DE-Lonetal West, 48.584053, 10.175744, 6
 EnBW DE-Lorsch Ost, 49.644328, 8.554109

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -754,6 +754,7 @@ Supercharger NL-Badhoevedorp, 52.329302, 4.78487
 Supercharger NL-Breda, 51.577493, 4.729968
 Supercharger NL-Breukelen, 52.167169, 4.98908
 Supercharger NL-Bunnik, 52.061077, 5.2055
+Supercharger-V3 NL-Deventer, 52.233798, 6.209399
 Supercharger NL-Dordrecht, 51.7744542, 4.65301
 Supercharger NL-Drachten, 53.105883, 6.129539
 Supercharger NL-Duiven, 51.958931, 6.020418
@@ -772,6 +773,7 @@ Supercharger-V3 NL-Meerkerk,51.899474,4.982747
 Supercharger-V3 NL-Middelburg, 51.480275, 3.636485
 Supercharger NL-Naarden, 52.30858, 5.141127
 Supercharger NL-Oosterhout, 51.626423, 4.869517
+Supercharger-V3 NL-Ridderkerk, 51.867786, 4.558687
 Supercharger-V3 NL-Rijswijk, 52.048276, 4.349078
 Supercharger NL-s-Hertogenbosch, 51.7205, 5.3334
 Supercharger-V3 NL-Sassenheim,52.213205,4.503374
@@ -786,6 +788,7 @@ Supercharger NL-Zevenaar, 51.940585, 6.081817
 Supercharger-V3 NL-Zuidbroek, 53.169567, 6.852949
 Supercharger NL-Zwolle, 52.531928, 6.157031
 Supercharger-V3 NL-Weert,51.281770, 5.650989
+Supercharger-V3 NL-Wolvega, 52.880495, 6.021328
 Supercharger-V3 NL-Tilburg,51.543084, 5.111792
 Supercharger NO-Aksdal, 59.423006, 5.44306
 Supercharger-V3 NO-Aksdal South, 59.421206, 5.4435

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -903,12 +903,19 @@ Supercharger RS-Aleksinac, 43.528816, 21.709413
 Supercharger RS-Belgrade, 44.710065, 20.561113
 Supercharger SE-Arboga, 59.426307, 15.827684
 Supercharger SE-Arvidsjaur, 65.589922, 19.184091
+Supercharger-V3 SE-Björkliden, 68.40734, 18.674918
 Supercharger SE-Borlänge, 60.478804, 15.438655
+Supercharger-V3 SE-Dorotea, 64.261428, 16.417156
 Supercharger SE-Edsbruk, 57.97985, 16.482407
 Supercharger SE-Enköping, 59.659057,17.076919
 Supercharger SE-Falkenberg, 56.931922,12.518628
 Supercharger SE-Grums, 59.365749, 13.14537
+Supercharger SE-Gäddede, 64.5065, 14.1435
 Supercharger SE-Gävle, 60.648513, 17.120583
+Supercharger-V3 SE-Gothenburg South, 57.6519635, 11.9512471
+Supercharger-V3 SE-Haninge, 59.1810494, 18.16069
+Supercharger-V3 SE-Helsingborg, 56.091, 12.76455
+Supercharger-V3 SE-Hogstorp, 58.393909, 11.757387
 Supercharger SE-Hudiksvall, 61.714854, 17.042692
 Supercharger SE-Jung, 58.328002, 13.132237
 Supercharger SE-Jäckvik, 66.39067, 16.964868
@@ -923,7 +930,11 @@ Supercharger SE-Krokom, 63.328793, 14.4301
 Supercharger SE-Kungälv, 57.8581639, 11.9982719
 Supercharger SE-Lagan, 57.028956, 14.014744
 Supercharger-V3 SE-Linköping, 58.435438, 15.590951
+Supercharger-V3 SE-Ljusdal, 61.827747, 16.094661
 Supercharger SE-Löddeköpinge, 55.766399, 12.990671
+Supercharger-V3 SE-Lycksele, 64.596066, 18.674414
+Supercharger-V3 SE-Malung, 60.685489, 13.713506
+Supercharger-V3 SE-Malå, 65.179347, 18.746649
 Supercharger-V3 SE-Mantorp, 58.3656796, 15.2939591, 30
 Supercharger-V3 SE-Mariestad,58.677066,13.815005
 Supercharger-V3 SE-Markaryd, 56.444825, 13.603916
@@ -931,10 +942,12 @@ Supercharger-V3 SE-Halmstad, 56.657389, 12.907444
 Supercharger SE-Markaryd, 56.444825, 13.603916
 Supercharger SE-Mellbystrand, 56.501606,12.95763
 Supercharger SE-Mora, 61.005921, 14.54418
+Supercharger-V3 SE-Nacka, 59.3112373, 18.1760186
 Supercharger SE-Nørre Alslev, 54.899885, 11.89693
 Supercharger SE-Norrköping, 58.62191, 16.154806
 Supercharger-V3 SE-Örebro, 59.297677, 15.206645, 40
 Supercharger SE-Puoltikasvaara, 67.440201, 21.115515
+Supercharger-V3 SE-Sälen, 61.163666, 13.203015
 Supercharger SE-Skellefteå, 64.76235, 21.002864
 Supercharger SE-Slagelse, 55.388, 11.3622
 Supercharger-V3 SE-Sollentuna, 59.496586,17.92444
@@ -943,6 +956,9 @@ Supercharger-V3 SE-Söderhamn, 61.294919, 17.0209945
 Supercharger SE-Stockholm, 59.5006239, 17.926818
 Supercharger SE-Storlien, 63.310045,12.109286
 Supercharger SE-Storuman, 65.092642, 17.107984
+Supercharger-V3 SE-Strängnäs, 59.328208, 17.017658
+Supercharger-V3 SE-Strömstad, 58.946329, 11.19394
+Supercharger-V3 SE-Sundsvall - West, 62.396129, 17.251596
 Supercharger SE-Sundsvall, 62.398468, 17.338902
 Supercharger SE-Sveg, 62.034484, 14.366261
 Supercharger SE-Tanum, 58.722128, 11.344127, 40
@@ -956,7 +972,13 @@ Supercharger SE-Umeå, 63.810547, 20.250437
 Supercharger SE-Uppsala, 59.939144, 17.656107
 Supercharger SE-Ödeshög, 58.227173, 14.668821
 Supercharger SE-Örnsköldsvik, 63.291556, 18.706134
+Supercharger-V3 SE-Övertorneå, 66.383535, 23.654794
+Supercharger-V3 SE-Växjö, 56.884262, 14.763464
 Supercharger-V3 SE-Varberg, 57.167879,12.27554
+Supercharger-V3 SE-Vetlanda, 57.415344, 15.090615
+Supercharger-V3 SE-Ystad, 55.434597, 13.839937
+Supercharger-V3 SE-Ånge, 62.537307, 15.919596
+Supercharger-V3 SE-Åsarna, 62.6408, 14.370883
 Supercharger SI-Kozina, 45.60492, 13.928521
 Supercharger SI-Kozina, 45.607449, 13.931531
 Supercharger SI-Ljubljana, 46.051778, 14.452056


### PR DESCRIPTION
Added the following chargers to geofence.csv:
- all missing superchargers in germany, italy, sweden, denmark, netherlands
- ENBW DE-Kriftel

If needed, I can also scan for changes in other countries. Let me know.