### PR TITLE
Compose V1 deprecration, Update docker_setup.md

### DIFF
--- a/docker_setup.md
+++ b/docker_setup.md
@@ -3,15 +3,15 @@ For Synology NAS users, check the hints here: [LINK](docker_setup_synology.md)
 
 Docker on Raspberry: It won't work if you don't have a 64bit OS as MariaDB requires a 64bit OS!
 
-Please make sure you have the latest docker and docker-compse. Many repositories comes with old docker and / or docker-compose. You can avoid a lot of problems by doblecheck it.
+Please make sure you have the latest docker and docker compose. Many repositories comes with old docker and / or docker compose. You can avoid a lot of problems by doblecheck it.
 
 These versions are known to work fine:
 ```
 docker -v
 Docker version 19.03.2, build 6a30dfca03
 
-docker-compose -v
-docker-compose version 1.24.1, build 4667896b
+docker compose -v
+docker compose version 1.24.1, build 4667896b
 ```
 
 1. Clone the Teslalogger repository into a new folder:
@@ -19,11 +19,11 @@ docker-compose version 1.24.1, build 4667896b
 git clone https://github.com/bassmaster187/TeslaLogger
 ```
 
-2. fire up docker containers. Make sure, you got the latest docker & docker-compose version. Many repositories comes with very old versions!
+2. fire up docker containers. Make sure, you got the latest docker & docker compose version. Many repositories comes with very old versions!
 ```
 cd TeslaLogger
-docker-compose build
-docker-compose up -d
+docker compose build
+docker compose up -d
 ```
 
 after a minute or two, everything should be ready. **On some slow machines or NAS, that could take more than 10 Minutes. I even heard about 30 Minutes.** Especially the database may take longer, so don't give up, if Teslalogger can't connect to the DB at the first startup. 
@@ -45,16 +45,16 @@ Enter Tesla credentials / Token to connect to your car.
 
 # Docker update / upgrade
 Usually, you update the Teslalogger in admin-panel by clicking on update button.
-If there are updates of the subsystem, you have to get the latest docker-compose.yam file.
+If there are updates of the subsystem, you have to get the latest docker compose.yam file.
 
 ```
-docker-compose stop
+docker compose stop
 git fetch
 git reset --hard origin/master
-git checkout origin/master -- docker-compose.yml
+git checkout origin/master -- docker compose.yml
 git checkout origin/master -- TeslaLogger/GrafanaConfig/datasource.yaml
-docker-compose build
-docker-compose up -d
+docker compose build
+docker compose up -d
 ```
 
 If Grafana won't start after upgrade try to give it all permissions. 


### PR DESCRIPTION
docker-compose (v1) is going to be deprecated very soon (or maybe it is already)

please use docker compose (v2, without hyphen)

see: https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/