### PR TITLE
Bugfix: Deleted illegal character after charge station

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -6220,7 +6220,7 @@ Lidl DE-Berlin Oberlandstraße 17, 52.465198, 13.416178
 Lidl DE-Berlin Prenzlauer Allee 93, 52.546596, 13.428866
 Lidl DE-Berlin Quickborner Straße, 52.603467, 13.367476
 Lidl DE-Berlin Seegefelder Weg 391, 52.546225, 13.142839
-Lidl DE-Berlin Sonnenallee, 52.475563, 13.451759#
+Lidl DE-Berlin Sonnenallee, 52.475563, 13.451759
 Lidl DE-Berlin Steglitzer Damm, 52.449291, 13.354343
 Lidl DE-Berlin Tempelhofer Damm 130, 52.467909, 13.38486
 Lidl DE-Berlin Vorarlberger Damm, 52.470054, 13.349763


### PR DESCRIPTION
The page Extras/Geofence did not load because of an unparsable character (#) at the end of a charging station in the geofence.csv.
New version of the file fixes the problem and a test of the page ran successful.