### PR TITLE
added further charging stations in DE (> 50 kW) to geofence.csv

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -7049,6 +7049,108 @@ LEW DE-Krumbach, 48.2450945, 10.3616606, 10
 LEW DE-Pfaffenhausen, 48.120746, 10.457604
 LEW DE-Pforzen, 47.933544, 10.607971
 
+LichtBlick DE-Andernach Am weißen Haus, 50.418419, 7.418061
+LichtBlick DE-Bad Fallingborstel Becklingr Str., 52.897467, 9.777757
+LichtBlick DE-Bad Königshofen Hoher Markstein, 50.306, 10.46498
+LichtBlick DE-Bad Marienberg Friedrichstraße, 50.65279, 7.95923
+LichtBlick DE-Bad Neustadt a. d. Saale Meininger Straße, 50.327433, 10.219865
+LichtBlick DE-Bad Neustadt a. d. Saale Mühlbacher Straße, 50.319909, 10.216899
+LichtBlick DE-Bad Neustadt a.d. Saale Roßmarktstraße, 50.32267, 10.2195
+LichtBlick DE-Bad Neustadt Schweinfurter Straße, 50.32021, 10.208691
+LichtBlick DE-Bad Segeberg Eutiner Straße, 53.950988, 10.312108
+LichtBlick DE-Bergen/Rügen Ringstraße, 54.423238, 13.421419
+LichtBlick DE-Bietigheim-Bissingen Buchstr., 48.945748, 9.145529
+LichtBlick DE-Bietigheim-Bissingen Rötestraße, 48.951933, 9.149448
+LichtBlick DE-Bietigheim-Bissingen Schwarzwaldstraße, 48.951294, 9.121405
+LichtBlick DE-Binzen Konrad-Zuse-Straße, 47.623705, 7.610557
+LichtBlick DE-Bitburg Graf-Zeppelin-Str., 49.56572, 6.32278
+LichtBlick DE-Buchen Hettinger Straße, 49.52214, 9.33259
+LichtBlick DE-Büchlberg Goldener Steig, 48.653005, 13.50688
+LichtBlick DE-Cham Rachelstraße, 49.2284, 12.67346
+LichtBlick DE-Coburg Bamberger Str., 50.252931, 10.962314
+LichtBlick DE-Coburg Max-Böhme-Ring, 50.279787, 10.973911
+LichtBlick DE-Coburg Neuer Weg, 50.255555, 10.958076
+LichtBlick DE-Coburg Rosenauer Straße, 50.27582752109, 10.983551285982
+LichtBlick DE-Coburg Wassergasse, 50.243085, 10.969389
+LichtBlick DE-Dessau-Roßlau Wörlitzer Platz, 51.841485, 12.240192
+LichtBlick DE-Ditzingen Heimerdinger Straße, 48.838079, 9.031756
+LichtBlick DE-Donauwörth Dillinger Str., 48.718102, 10.764606
+LichtBlick DE-Eibelstadt Am Thomasboden, 49.736083, 9.989747
+LichtBlick DE-Estenfeld Am Zehnthügel, 49.832468, 10.006501
+LichtBlick DE-Eutin Berliner Platz, 54.133864, 10.615343
+LichtBlick DE-Eutin Holstenstraße, 54.142029660299, 10.612464985932
+LichtBlick DE-Freudenstadt Wildbaderstraße, 48.468776, 8.405564
+LichtBlick DE-Fulda Dr. Raabe-Str., 50.551523, 9.716856
+LichtBlick DE-Gaggenau Eckenerstraße, 48.796596, 8.312393
+LichtBlick DE-Geesthacht Geesthacht-Spandauer Straße, 53.434, 10.34274
+LichtBlick DE-Geiersthal Piflitz, 49.0551, 13.00831
+LichtBlick DE-Gelnhausen Krempsche Spitz, 50.207453, 9.221903
+LichtBlick DE-Gemünden Würzburger Straße, 50.061858, 9.677391
+LichtBlick DE-Großheirath Kehrlesgasse, 50.178866, 10.907829
+LichtBlick DE-Günterleben Fahrentalstraße, 49.859775, 9.89587
+LichtBlick DE-Haßfurt Ohmstraße, 50.03764, 10.534814
+LichtBlick DE-Haßfurt Robert-Bosch-Straße, 50.033127, 10.543527
+LichtBlick DE-Heldburg OT Bad Colberg Hauptstraße, 50.275559, 10.799837
+LichtBlick DE-Herborn Schießplatz, 50.679828, 8.306415
+LichtBlick DE-Herrenberg Daimlerstraße, 48.603317, 8.871454
+LichtBlick DE-Höchberg Einsteinstraße, 49.772661, 9.871018
+LichtBlick DE-Hohen Neuendorf Oranienburger Straße, 52.673358, 13.281858
+LichtBlick DE-Hohen Neuendorf Puschkinallee, 52.670058, 13.288027
+LichtBlick DE-Kahl am Main Am Christnersee, 50.077076, 9.012106
+LichtBlick DE-Kaufbeuren Füssener Str., 47.87142, 10.62865
+LichtBlick DE-Kaufbeuren/Neugablonz Sudetenstrasse, 47.90372, 10.63826
+LichtBlick DE-Kiel Grot Steenbusch, 54.283798, 10.132107
+LichtBlick DE-Kiel Seekoppelweg, 54.299298, 10.086525
+LichtBlick DE-Kitzingen Im Richthofen Circle, 49.747972, 10.188363
+LichtBlick DE-Künzelsau Dieselstraße, 49.258091000217, 9.6780602504549
+LichtBlick DE-Laichingen Wilhelm-Maybach-Straße, 48.493278, 9.711083
+LichtBlick DE-Landau an der Isar Kleegartenstraße, 48.686023, 12.712283
+LichtBlick DE-Landshut Parkplatz Grieserwiese, 48.531097, 12.145354
+LichtBlick DE-Lauterbach Bleichstraße, 50.638312, 9.402692
+LichtBlick DE-Lautertal Reutersgasse, 50.295118, 10.980004
+LichtBlick DE-Lippstadt Eickelbornstr., 51.653244, 8.214608
+LichtBlick DE-Ludwigslust Hamburger Tor, 53.321166, 11.486557
+LichtBlick DE-Ludwigslust Käthe-Kollwitz-Straße, 53.32416, 11.49941
+LichtBlick DE-Ludwigslust Rudolf-Tarnow-Straße, 53.33421, 11.4938
+LichtBlick DE-Markgröningen Im Tuchgraben (Festplatz), 48.90725, 9.078938
+LichtBlick DE-Mellrichstadt Sondheimer Straße, 50.4295, 10.307
+LichtBlick DE-Neuberg Langenselbolder Straße, 50.185652, 8.999203
+LichtBlick DE-Neustadt in Holstein Rettiner Weg, 54.103684, 10.833596
+LichtBlick DE-Niederfüllbach Carl-Brandt-Straße, 50.221281, 10.984691
+LichtBlick DE-Nieheim Alersfelde, 51.8091, 9.12885
+LichtBlick DE-Nortorf Große Mühlenstraße, 54.168978256729, 9.8542087548065
+LichtBlick DE-Oberelsbach Auweg, 50.441938, 10.120475
+LichtBlick DE-Oberpöring Oberpöringermoos, 48.713452, 12.810404
+LichtBlick DE-Ofterdingen Haidschwärze, 48.425833, 9.040556
+LichtBlick DE-Oldenburg Am Voßberg, 54.292711, 10.910778
+LichtBlick DE-Osterburken Rosenberger Straße, 49.429786, 9.436962
+LichtBlick DE-Pantelitz Lindenstraße, 54.297878, 12.97134
+LichtBlick DE-Pilsting Waldstraße, 48.724938, 12.637052
+LichtBlick DE-Pinneberg Flensburger Straße, 53.672374, 9.802325
+LichtBlick DE-Plön Stadtgrabenstraße, 54.159143966226, 10.417594331928
+LichtBlick DE-Pritzwalk Meyenburger Tor, 53.151804, 12.177141
+LichtBlick DE-Saarbrücken St.Johanna-Str. 101-105, 49.238281, 6.978495
+LichtBlick DE-Schweinfurt Bodelschwinghstraße, 50.050643, 10.217338
+LichtBlick DE-Schweinfurt Deutschhöfer Str., 50.054093, 10.22982
+LichtBlick DE-Seßlach Dietersdorfer Straße, 50.21794, 10.825727
+LichtBlick DE-Sindelfingen Flugfeld-Allee, 48.689925690905, 8.9938323828354
+LichtBlick DE-Sömmerda Parkweg, 51.165103, 11.117362
+LichtBlick DE-Stalsund Koppelstraße, 54.282629, 13.085243
+LichtBlick DE-Staßfurt Am Heidfuchsberg, 51.896969, 11.692548
+LichtBlick DE-Staßfurt Lehrter Str., 51.85448, 11.58218
+LichtBlick DE-Theilheim Randersackerer Str., 49.752914, 10.016214
+LichtBlick DE-Wadgassen Pater-Lorson-Straße, 49.236972, 6.773917
+LichtBlick DE-Wadgassen Saarstraße, 49.271529, 6.792587
+LichtBlick DE-Weil der Stadt Merklinger Straße, 48.754265, 8.868948
+LichtBlick DE-Wettenberg Launsbach Am Volpertstriesch, 50.622510217742, 8.6555462318548
+LichtBlick DE-Weyhe Ladestraße, 52.994101, 8.819546
+LichtBlick DE-Winsen Luhe Löhnfeld, 53.363045, 10.192888
+LichtBlick DE-Würzburg Am Handelshof, 49.818515, 9.986064
+LichtBlick DE-Würzburg Nürnberger Straße, 49.796359, 9.977662
+LichtBlick DE-Würzburg Paradeplatz, 49.792957, 9.932753
+LichtBlick DE-Würzburg Salvatorstraße, 49.791594, 9.953112
+LichtBlick DE-Würzburg Zeppelinstraße, 49.780324, 9.964992
+
 Lidl AT-Alkoven,48.2870556,14.1439429
 Lidl AT-Altenmarkt,47.3810373,13.4302684
 Lidl AT-Ansfelden, 48.214815, 14.276056

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -2089,6 +2089,163 @@ chargeIT DE-Petershausen, 48.416818, 11.478081
 chargeIT DE-Saarlouis, 49.290288,6.758827, 20
 chargeIT DE-Ungerhausen, 48.017723, 10.270062
 
+ChargePoint DE-Abensberg 13 Werkstraße, 48.807684, 11.877103
+ChargePoint DE-Achern Wilhelm-Schechter-Straße 15, 48.628471, 8.07108
+ChargePoint DE-Alsdorf 29A Carl-Zeiss-Straße, 50.869671874695, 6.1810571243286
+ChargePoint DE-Augsburg 73 Haunstetter Str, 48.347747460926, 10.905941593273
+ChargePoint DE-Bad Bergzabern Meßplatz, 49.100529, 7.996499
+ChargePoint DE-Bad Krozingen Thürachstraße 4, 47.917615, 7.688745
+ChargePoint DE-Bad Langensalza Mühlhäuser Landstraße 15, 51.111804, 10.638847
+ChargePoint DE-Bad Säckingen 6 Am Buchrain, 47.555409226219, 7.9279937325363
+ChargePoint DE-Bad Sooden-Allendorf Werrastraße 13, 51.264148, 9.975227
+ChargePoint DE-Bamberg 38 Kronacher Str., 49.918677, 10.902675
+ChargePoint DE-Baunatal Fuldastraße 1-5, 51.227693, 9.427353
+ChargePoint DE-Berge 45 Hauptstraße, 52.621123, 7.749758
+ChargePoint DE-Berghaupten Auf dem Grün 1, 48.416427, 7.985731
+ChargePoint DE-Berlin 212-1930 Salzufer, 52.515382113223, 13.330297982932
+ChargePoint DE-Bersenbrück 11 Ankumer Straße, 52.556010476336, 7.9429473808427
+ChargePoint DE-Bielefeld Bechterdisser Straße 5, 52.013807, 8.619195
+ChargePoint DE-Blaubeuren 17 Ehinger Straße, 48.4033285, 9.77963175
+ChargePoint DE-Böblingen 20 Rudolf-Diesel-Straße, 48.675462917946, 9.0173323604322
+ChargePoint DE-Bönnigheim Industriestraße 37, 49.044492, 9.104449
+ChargePoint DE-Bottrop 2 Raiffeisenstraße, 51.60861311772, 6.9329104706473
+ChargePoint DE-Bünde 77 Lange Straße, 52.207286, 8.57763
+ChargePoint DE-Burg auf Fehmarn Landkirchener Weg 38, 54.442383, 11.181872
+ChargePoint DE-Chemnitz Blankenburgstraße 67, 50.860795306641, 12.91045203125
+ChargePoint DE-Dachau Fraunhoferstraße 5, 48.262487120071, 11.474035041339
+ChargePoint DE-Darmstadt 100 Rheinstraße, 49.868889923356, 8.6322204932498
+ChargePoint DE-Dortmund 99 Wittekindstraße, 51.496253, 7.442489
+ChargePoint DE-Dresden Wiener Platz 3, 51.042352, 13.730745300407
+ChargePoint DE-Düren 15 Bahnstraße, 50.789466, 6.46766
+ChargePoint DE-Düsseldorf 11-15 Bertha-von-Suttner-Straße, 51.132798, 6.906795
+ChargePoint DE-Düsseldorf 1 Mercedesstraße, 51.250198194118, 6.7992892249993
+ChargePoint DE-Ebersbach an der Fils 5 Fabrikstraße, 48.716303011972, 9.5368096430504
+ChargePoint DE-Ehningen Birkensee 1, 48.65099, 8.9453
+ChargePoint DE-Elchingen 3 Robert-Bosch-Straße, 48.453132, 10.102126
+ChargePoint DE-Engstingen 12 Meidelstetter Straße, 48.386098366392, 9.2874283479097
+ChargePoint DE-Erbach 1 Am Graben, 48.340607706338, 9.8181721138706
+ChargePoint DE-Erfurt Hermsdorfer Straße 2, 50.972502388863, 11.05791618026
+ChargePoint DE-Erfurt Holzlandstraße 4, 50.973952999573, 11.061911328064
+ChargePoint DE-Erfurt Rudolstädter Straße 19, 50.972116, 11.054295
+ChargePoint DE-Erfurt Schwerborner Straße 30c, 51.013664, 11.040337
+ChargePoint DE-Erfurt Vollbrachtstraße 14, 51.004048, 11.025274
+ChargePoint DE-Ergolding 32 Moosfeldstraße, 48.56055451111, 12.15790736601
+ChargePoint DE-Eschenlohe 12 Blauänger, 47.612331, 11.194188
+ChargePoint DE-Esslingen am Neckar 43 Alleenstraße, 48.724699, 9.348045
+ChargePoint DE-Esslingen am Neckar 6 Ottostraße, 48.737261, 9.29369
+ChargePoint DE-Euskirchen 44-46 Eifelring, 50.653119421221, 6.7925841385905
+ChargePoint DE-Fahrenbach 1 Ampereweg, 49.42613, 9.155845
+ChargePoint DE-Fellbach 102 Pestalozzistraße, 48.82023468325, 9.2738982251813
+ChargePoint DE-Fellbach 68-70 Waiblinger Straße, 48.813512, 9.282268
+ChargePoint DE-Forst Karl-Wirth-Straße 100, 49.158057, 8.57384
+ChargePoint DE-Frankfurt am Main Hanauer Landstraße 295, 50.117069687776, 8.727110457252
+ChargePoint DE-Frankfurt am Main Heinrich-Lanz-Allee, 50.193605, 8.642257
+ChargePoint DE-Frankfurt am Main Schwarzwaldstraße 92, 50.083410609375, 8.650086234375
+ChargePoint DE-Freiburg im Breisgau Kappler Straße 58, 47.980468, 7.904277
+ChargePoint DE-Friesoythe 1 Bürgermeister-Olberding-Straße, 53.021811, 7.882554
+ChargePoint DE-Fürth 90 Flugplatzstraße, 49.501085, 10.966131
+ChargePoint DE-Fürth Schwabacher Straße 382, 49.443394451554, 10.9904330968
+ChargePoint DE-Gescher Porschestraße 2-4, 51.960739, 6.988553
+ChargePoint DE-Göppingen 22 Leonhard-Weiss-Straße, 48.701008002195, 9.6706407514625
+ChargePoint DE-Göppingen 3 Heilbronner Str, 48.695128172161, 9.6788706065928
+ChargePoint DE-Goslar Dörntener Str. 2a, 51.924466, 10.415264
+ChargePoint DE-Gransee 13a Kraatzer Weg, 53.003102177246, 13.170179415527
+ChargePoint DE-Gütersloh 10 Dalkestraße, 51.9014805, 8.37777675
+ChargePoint DE-Gütersloh 24 Goethestraße, 51.916999411499, 8.3857722553101
+ChargePoint DE-Gütersloh 25 James-Watt-Straße, 51.920729475333, 8.4070221953988
+ChargePoint DE-Gütersloh 48 Carl-Miele-Straße, 51.910518, 8.396586
+ChargePoint DE-Hansestadt Seehausen Märsche 2, 52.97321, 11.7368
+ChargePoint DE-Hauzenberg 5 Wastlmühlstraße, 48.627852, 13.643701
+ChargePoint DE-Heidbecker, 53.581417949548, 9.4955220664232
+ChargePoint DE-Hilden 2 Düsseldorfer Straße, 51.166008770517, 6.9211315195389
+ChargePoint DE-Hildesheim 6 Daimlerring, 52.163728, 9.98888
+ChargePoint DE-Höhenkirchen-Siegertsbrunn Sportplatzstraße 4, 48.02314822647, 11.701994307353
+ChargePoint DE-Hunding 1 Gewerbedorf, 48.838488513672, 13.15101240332
+ChargePoint DE-Ibbenbüren 27 Gutenbergstr., 52.259939, 7.725492
+ChargePoint DE-Idstein Black & Decker Straße 5-7, 50.213596, 8.254632
+ChargePoint DE-Ingolstadt 110 Manchinger Strasse, 48.747786, 11.463096
+ChargePoint DE-Ingolstadt 80 Manchinger Strasse, 48.753177, 11.449721
+ChargePoint DE-Kaltenkirchen Borsigstrasse 7, 53.820714, 9.977591
+ChargePoint DE-Kamenz 94 Nordstraße, 51.299383463785, 14.091527885982
+ChargePoint DE-Kappeln Nordstraße 3, 54.665216, 9.920648
+ChargePoint DE-Kappelrodeck Binzigstraße 27, 48.597687, 8.112775
+ChargePoint DE-Kassel 167 Frankfurter Straße, 51.296514593727, 9.479835586725
+ChargePoint DE-Kassel Dresdener Straße 5, 51.312645793907, 9.5134434227604
+ChargePoint DE-Kassel Frankfurter Straße 315, 51.282092, 9.465317
+ChargePoint DE-Kassel Leipziger Straße 228, 51.298935309689, 9.5373697580738
+ChargePoint DE-Kassel Leipziger Straße 291b, 51.2971043677, 9.5421772105432
+ChargePoint DE-Kassel Ochshäuser Straße 37, 51.298609, 9.53366
+ChargePoint DE-Kehl Am Läger 1, 48.574759, 7.814588
+ChargePoint DE-Kirchdorf an der Iller 23 Liebherrstraße, 48.077661, 10.131289
+ChargePoint DE-Kirchlengern 7 Sunderhofstraße, 52.248722916095, 8.6370969509323
+ChargePoint DE-Kißlegg 26 Eugen-Bolz-Straße, 47.792777000479, 9.8862539999565
+ChargePoint DE-Köln 41 Richard-Byrd-Straße, 50.990029232265, 6.8899504598143
+ChargePoint DE-Kornwestheim 18 Albstraße, 48.851372, 9.187688
+ChargePoint DE-Kornwestheim 1 Leibnizstraße, 48.866988, 9.198783
+ChargePoint DE-Kraftisried Mühlenstraße, 47.776997, 10.477797
+ChargePoint DE-Laaber 2 Reiserweg, 49.0886130625, 11.884990140625
+ChargePoint DE-Landau An der Kreuzmühle 2, 49.197494, 8.0906
+ChargePoint DE-Landau Fichtenstraße 36, 49.211056, 8.138861
+ChargePoint DE-Landau in der Pfalz August-Croissant-Straße 27, 49.206425, 8.122297
+ChargePoint DE-Landau in der Pfalz Gilletstraße 5, 49.211596, 8.120238
+ChargePoint DE-Landau in der Pfalz Langstraße 9, 49.198497, 8.110684
+ChargePoint DE-Landau in der Pfalz Wollmesheimer Höhe 8, 49.187103, 8.093244
+ChargePoint DE-Lübbecke 115 Rahdener Straße, 52.319177646484, 8.6142833476563
+ChargePoint DE-Lübbecke 4 Am Zollamt, 52.3098816875, 8.6331526875
+ChargePoint DE-Ludwigsburg 140 Schwieberdinger Str., 48.890526744798, 9.1582236341937
+ChargePoint DE-Ludwigsburg 57 Teinacher Straße, 48.903389663072, 9.1655159045227
+ChargePoint DE-Lütjenburg Gildenplatz, 54.292887, 10.594415
+ChargePoint DE-Magdeburg Parchauer Straße 1h, 52.199092, 11.672448
+ChargePoint DE-Melle 8 Ochsenweg, 52.21494975, 8.31714675
+ChargePoint DE-Montabaur Staufenbergallee, 50.427142, 7.820981
+ChargePoint DE-Mücheln (Geiseltal) 1B Bahnhofsiedlung, 51.347096128731, 11.755119571201
+ChargePoint DE-Neuried Schopfheimer Straße 3, 48.430376, 7.814011
+ChargePoint DE-Neuss 4 Im Taubental, 51.166855856095, 6.7582679011682
+ChargePoint DE-Nürnberg 14 Kressengartenstraße, 49.449933662618, 11.099393534292
+ChargePoint DE-Nürnberg 97 Flughafenstraße, 49.493548205079, 11.080216746088
+ChargePoint DE-Nürnberg Marienbergstraße 88, 49.485071724872, 11.093443064297
+ChargePoint DE-Oberding Flughafen Südring P36 Delivery, 48.352941, 11.816863
+ChargePoint DE-Olpe 5 Ziegeleistraße, 51.038328, 7.86167
+ChargePoint DE-Ostbevern 57 Loburg, 52.036928, 7.857509
+ChargePoint DE-Pfaffenhofen an der Ilm 6 Otto-Hahn-Straße, 48.544990051851, 11.513348921456
+ChargePoint DE-Pfarrkirchen 10 Südeinfahrt, 48.417208, 12.944784
+ChargePoint DE-Pfarrkirchen 12 Franz-Stelzenberger-Straße, 48.418996, 12.937338
+ChargePoint DE-Pförring 2 Max-Pollin-Straße, 48.816609834932, 11.693815872728
+ChargePoint DE-Pforzheim 32 Karlsruher Straße, 48.903297050023, 8.6586843500209
+ChargePoint DE-Pforzheim 52 Habermehlstraße, 48.89070058486, 8.6818783935116
+ChargePoint DE-Pfullendorf Otterswanger Straße 1, 47.9295214, 9.2427606
+ChargePoint DE-Remscheid 17 Fritz-Reuter-Straße Bäckerei, 51.194143, 7.27069
+ChargePoint DE-Remshalden 37 Fellbacher Straße, 48.814702682031, 9.4153128789037
+ChargePoint DE-Rheine 4 Carl-Zeiss-Straße, 52.287844, 7.484384
+ChargePoint DE-Satteldorf 2-3 Leonhard-Weiss-Straße, 49.181350597153, 10.076292584396
+ChargePoint DE-Schiltach Hauptstraße 74, 48.291409, 8.35218
+ChargePoint DE-Schöneck/Vogtland Waldstraße 7, 50.394936, 12.34484
+ChargePoint DE-Schönefeld 61 Hans-Grade-Allee, 52.39602600276, 13.517067319766
+ChargePoint DE-Schöngeising Gusso-Reuss-Straße 12, 48.14604, 11.204441
+ChargePoint DE-Schorndorf 11/1 Gerberstraße, 48.804729977657, 9.5155475558483
+ChargePoint DE-Schorndorf 40 Baumwasenstraße, 48.806652770849, 9.5099346064054
+ChargePoint DE-Schwäbisch Gmünd 40 Im Benzfeld, 48.805835015625, 9.8471310571289
+ChargePoint DE-Schwäbisch Gmünd Buchstraße 200, 48.801027, 9.833086
+ChargePoint DE-Sebnitz 72 Schandauer Straße, 50.967752, 14.254259
+ChargePoint DE-Spelle 5 Dreierwalder Straße, 52.358486455165, 7.4770578508643
+ChargePoint DE-Spenge 25 Industriestraße, 52.144728920282, 8.4962697146245
+ChargePoint DE-Speyer 2 Geibstraße, 49.3143944625, 8.4464511375
+ChargePoint DE-Tecklenburg 10 Wechter Straße, 52.22104229997, 7.7479267499463
+ChargePoint DE-Trierweiler 12 Kiemstraße, 49.772362, 6.583194
+ChargePoint DE-Ummendorf / Börde Meyendorffstraße 2, 52.155919, 11.182358
+ChargePoint DE-Velen 23 Ostendorfer Str, 51.883738054689, 6.9214924890566
+ChargePoint DE-Waidhaus 7 Hauptstraße, 49.641117, 12.493605
+ChargePoint DE-Waldkraiburg 12 Zirndorfer Straße, 48.21757256826, 12.415857903788
+ChargePoint DE-Weimar Erfurter Straße 76, 50.981225800454, 11.309937
+ChargePoint DE-Weinstadt 1 Heerbergstraße, 48.814300968132, 9.3579146004082
+ChargePoint DE-Weißenburg in Bayern 2 Treuchtlinger Straße, 49.019316351253, 10.960393415667
+ChargePoint DE-Wemding 1 Kehläcker, 48.87155225525, 10.705207764924
+ChargePoint DE-Werlte Am Arenberge 1, 52.84428, 7.6541820000002
+ChargePoint DE-Wesseling 37-39 Industriestraße, 50.83438, 6.951348
+ChargePoint DE-Wilburgstetten 1 Karl-Ruf-Straße, 49.017365, 10.397403
+ChargePoint DE-Wörthsee 11 Inninger Straße, 48.085497783142, 11.199360912781
+ChargePoint DE-Würzburg 10a Friedrichstraße, 49.797157247392, 9.9147705126479
+
 CEZ CZ-Děčín, 50.770023, 14.207249
 CEZ CZ-Jenišov, 50.222744, 12.805259
 CEZ CZ-Jaroměř, 50.342834, 15.904088

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -3148,6 +3148,131 @@ E.ON DK-Karlslunde West, 55.560857, 12.229259
 E.ON DK-Karlslunde Ost, 55.560657, 12.231491
 E.ON DK-Korsør, 55.347704, 11.120238
 
+EDEKA DE-Ahorn Lindenstraße, 50.23425, 10.9182
+EDEKA DE-Asendorf Altenfelder Weg, 52.77811, 9.00129
+EDEKA DE-Bad Belzig Weitzgrunder Str, 52.14475, 12.59097
+EDEKA DE-Barleben Breiteweg, 52.19387, 11.6233
+EDEKA DE-Barntrup Försterweg, 51.98629, 9.1346
+EDEKA DE-Bergatreute Roßberger Straße, 47.84903, 9.75231
+EDEKA DE-Berlin Blankenburger Str., 52.58477, 13.41664
+EDEKA DE-Berlin Britzer Straße, 52.43921, 13.41118
+EDEKA DE-Berlin Eichborndamm, 52.57519, 13.31438
+EDEKA DE-Berlin Heerstraße, 52.515648235294, 13.185989411765
+EDEKA DE-Berlin Potsdamer Chaussee, 52.42695, 13.21664
+EDEKA DE-Berlin Rixdorfer Str., 52.44786, 13.40464
+EDEKA DE-Berlin Siemensstraße, 52.44419, 13.33582
+EDEKA DE-Berlin Wiesbadener Straße, 52.47348, 13.30219
+EDEKA DE-Bernburg Gröbziger Straße, 51.78841, 11.75377
+EDEKA DE-Binz OT Prora Vierte Str., 54.44277, 13.56765
+EDEKA DE-Bocholt Dinxperloerstr., 51.85394, 6.59379
+EDEKA DE-Bocholt Wigger Str., 51.86016, 6.49928
+EDEKA DE-Bochum Wasserstr., 51.46386, 7.23712
+EDEKA DE-Bonn Basketring, 50.70666, 7.05997
+EDEKA DE-Bremen Rockwinkeler Heerstraße, 53.08955, 8.93263
+EDEKA DE-Bruchköbel Bahnhofstraße, 50.18399, 8.92312
+EDEKA DE-Bünde Herforder Straße, 52.18835, 8.59885
+EDEKA DE-Bünde Wilhelmstraße, 52.20135, 8.57253
+EDEKA DE-Burgbernheim Bergeler Str., 49.44851, 10.33049
+EDEKA DE-Butjadingen Butjadinger Straße, 53.5764, 8.35895
+EDEKA DE-Celle Dörnbergstraße, 52.62747, 10.09957
+EDEKA DE-Coppenbrügge Alte Heerstraße, 52.116, 9.55597
+EDEKA DE-Coswig-Anhalt Berliner Straße, 51.8921, 12.46464
+EDEKA DE-Datteln Schachtstr., 51.63416, 7.33283
+EDEKA DE-Dortmund Nelkenstr., 51.47759, 7.59982
+EDEKA DE-Dresden Dohnaer Str., 51.0085, 13.78422
+EDEKA DE-Dresden Holbeinstr., 51.04902, 13.76994
+EDEKA DE-Dülmen Auf dem Quellberg, 51.84274, 7.29472
+EDEKA DE-Eichstätt Weißenburger Straße, 48.89651, 11.17584
+EDEKA DE-Eilenburg Ziegelstr., 51.46355, 12.64697
+EDEKA DE-Erding Pretzener Str, 48.27278, 11.89633
+EDEKA DE-Erkelenz Karolingerring, 51.09054, 6.32004
+EDEKA DE-Essen Velberterstr., 51.38861, 7.01252
+EDEKA DE-Fehrbellin Berliner Allee, 52.80862, 12.77719
+EDEKA DE-Freital Oppelstr., 51.01597, 13.63717
+EDEKA DE-Fürstenwalde Lange Straße, 52.34712, 14.05708
+EDEKA DE-Gaimersheim Dr.-Ludwig-Kraus-Straße, 48.79086, 11.378
+EDEKA DE-Geiselbach Omersbacher Weg, 50.10886, 9.19192
+EDEKA DE-Geldern Annastr., 51.51793, 6.34108
+EDEKA DE-Genthin Geschwister-Scholl-Straße, 52.40835, 12.16029
+EDEKA DE-Gevelsberg Wittener Str., 51.33023, 7.33646
+EDEKA DE-Goch Sandthof, 51.66679, 6.17664
+EDEKA DE-Greven Bismarckstraße, 52.09806, 7.61899
+EDEKA DE-Großbeeren Dorfaue, 52.35276, 13.30596
+EDEKA DE-Gütersloh Rhedaer Str., 51.89355, 8.36366
+EDEKA DE-Halle (Saale) Weißenfelser Straße, 51.43748, 11.97292
+EDEKA DE-Halle (Saale) Wilhelm-von-Klewiz-Straße, 51.4428, 11.96655
+EDEKA DE-Hamburg Neuer Kamp, 53.55554, 9.967
+EDEKA DE-Hannover Grethe-Jürgens-Str., 52.40297, 9.7892
+EDEKA DE-Herford Elverdisser Straße, 52.07778, 8.65122
+EDEKA DE-Herford Goebenstraße, 52.12353, 8.66813
+EDEKA DE-Herten Hoppenwall, 51.61818, 7.07912
+EDEKA DE-Hettstedt Eislebener Straße, 51.63566, 11.51278
+EDEKA DE-Hohenhameln Schützenstr, 52.26144, 10.06665
+EDEKA DE-Höhn Am Gewerbepark, 50.61707, 7.97911
+EDEKA DE-Holzwickede Kirchstr., 51.49923, 7.61937
+EDEKA DE-Joachimsthal Templiner Str., 52.9783, 13.74416
+EDEKA DE-Kevelaer Feldstr., 51.57975, 6.2558
+EDEKA DE-Kevelaer Kevelaerer Str., 51.59794, 6.27951
+EDEKA DE-Kiel Hamburger Chaussee, 54.29949, 10.10442
+EDEKA DE-Kirchlengern In der Mark, 52.20762, 8.65131
+EDEKA DE-Köln Godorfer Haupstraße, 50.8577, 6.97468
+EDEKA DE-Köln Longericher Str., 50.99742, 6.914
+EDEKA DE-Kösching Ingolstädter Straße, 48.80913, 11.48145
+EDEKA DE-Langenhagen Hannoversche Strasse / Stadtweg, 52.44303, 9.66941
+EDEKA DE-Lebach-Thalexweiler Steinbacher Str., 49.44826, 6.96455
+EDEKA DE-Leipzig Lindenthaler Hauptstr., 51.39018, 12.32761
+EDEKA DE-Leipzig Wittenberger Straße, 51.35973, 12.38563
+EDEKA DE-Lippstadt Otto-Hahn-Str., 51.65636, 8.32977
+EDEKA DE-Lübben (Spreewald) Berliner Chaussee, 51.94511, 13.8863
+EDEKA DE-Mantel Weidenerstr., 49.65608, 12.04742
+EDEKA DE-Meerbusch-Osterath Gottlieb-Daimler-Str., 51.26961, 6.62745
+EDEKA DE-Meinersen-Ohof Schwarzer Weg, 52.45172, 10.31141
+EDEKA DE-Minden Lübbecker Straße, 52.27261, 8.86602
+EDEKA DE-Mittenwalde An der Feuerwehr, 52.26018, 13.53958
+EDEKA DE-Moers Edekaplatz, 51.46989, 6.63324
+EDEKA DE-Moers Römerstr., 51.44172, 6.66245
+EDEKA DE-Mülheim a. d. Ruhr Düsseldorfer Str., 51.4071, 6.87033
+EDEKA DE-Müllrose Alte Poststraße, 52.2415, 14.41105
+EDEKA DE-Naumburg Overwegstr., 51.15758, 11.82071
+EDEKA DE-Neumünster Gadelander Straße, 54.0512, 9.98892
+EDEKA DE-Neunkirchen Zeithstr., 50.87214, 7.32502
+EDEKA DE-Neuss Schellbergstr., 51.16722, 6.7347
+EDEKA DE-Nienburg Verdener Landstraße, 52.65336, 9.21689
+EDEKA DE-Oberhausen Goldammerweg, 51.52451, 6.82454
+EDEKA DE-Oer-Erkenschwick Industriestr., 51.63899, 7.27763
+EDEKA DE-Otterndorf Marktstraße, 53.80776, 8.90621
+EDEKA DE-Paderborn Alisostr., 51.73503, 8.68189
+EDEKA DE-Paderborn Alter Hellweg, 51.68767, 8.69684
+EDEKA DE-Paderborn Detmolder Str., 51.72323, 8.75927
+EDEKA DE-Papenburg Kapitän-Venema-Straße, 53.08205, 7.41971
+EDEKA DE-Peine Lindenstraße, 52.32029, 10.22902
+EDEKA DE-Peine Woltorfer Weg, 52.32045, 10.23364
+EDEKA DE-Petershagen Lessingstraße, 52.53008, 13.79142
+EDEKA DE-Randersacker Am Sonnenstuhl, 49.75312, 9.98715
+EDEKA DE-Ransbach-Baumbach Pleurtuit-Str., 50.46398, 7.72463
+EDEKA DE-Ratingen Am Sandbach, 51.29717, 6.83118
+EDEKA DE-Regensburg-Galgenberg Franz-Mayer-Straße, 49.00112, 12.105
+EDEKA DE-Schwedt Landgrabenpark, 53.06554, 14.27345
+EDEKA DE-Sinzig Kölnerstr., 50.54706, 7.24557
+EDEKA DE-Sörup Bahnhofstraße, 54.71902, 9.67769
+EDEKA DE-Spenge Industriestraße, 52.1444, 8.49103
+EDEKA DE-Stadtilm Weimarische Str., 50.77705, 11.08792
+EDEKA DE-Steinhorst Marktstraße, 52.68994, 10.40538
+EDEKA DE-Stolzenau Bürgermeister-Heuvemann-Str., 52.51124, 9.06146
+EDEKA DE-Sulzbach-Rosenberg Rosenberger Str., 49.50382, 11.74461
+EDEKA DE-Thedinghausen Syker Straße, 52.96111, 9.0187
+EDEKA DE-Troisdorf Marie-Lene-Rödder-Str., 50.80285, 7.14504
+EDEKA DE-Uplengen - Remels Ostertorstrasse, 53.30373, 7.74563
+EDEKA DE-Varel Wiefelsteder Straße, 53.37576, 8.10365
+EDEKA DE-Viechtach Schmidstraße, 49.07858, 12.88105
+EDEKA DE-Waltrop Am Moselbach, 51.62467, 7.39915
+EDEKA DE-Wesendorf Gifhorner Str., 52.59039, 10.53374
+EDEKA DE-Wiesmoor Hauptstraße, 53.41759, 7.73964
+EDEKA DE-Wilsdruff OT Mohorn Mohorner Höhe, 50.99391, 13.45434
+EDEKA DE-Wittingen Bromer Str., 52.64494, 10.86819
+EDEKA DE-Wrist Eken, 53.92854, 9.75124
+EDEKA DE-Zossen Gutstedtstraße, 52.17, 13.47159
+
 ELEN HR-Kanfanar, 45.12281,1383895
 ELEN HR-Motovun, 45.331222,13.824982
 ELEN HR-Opatija Štangerova, 45.347349,14.319122

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -7178,6 +7178,61 @@ Pfalzwerke DE-Wörth am Rhein Marktstraße , 49.052111, 8.253056
 Pfalzwerke DE-Würzburg Am Handelshof 9 , 49.816089527619, 9.9813920773437
 Pfalzwerke DE-Zweibrücken Wilkstraße 2 , 49.251736346139, 7.3445107002955
 
+Porsche DE-Aschaffenburg Berliner Allee, 49.9651, 9.1721839682579
+Porsche DE-Bamberg Kärntenstraße, 49.911, 10.9031
+Porsche DE-Bayreuth Wolfsbacher Straße, 49.9092, 11.6067
+Porsche DE-Berlin Hermann-Dorner-Allee, 52.427601887894, 13.5194
+Porsche DE-Bonn Brühler Straße, 50.7417, 7.07395
+Porsche DE-Braunschweig Trautenaustraße, 52.2812, 10.49945
+Porsche DE-Chemnitz Tuchschererstraße, 50.805, 12.8559
+Porsche DE-Darmstadt Hilpertstraße, 49.8631, 8.62955
+Porsche DE-Dortmund Carrera Strasse, 51.515266666412, 7.615656667099
+Porsche DE-Dresden Meinholdstraße, 51.0983, 13.731933334923
+Porsche DE-Düsseldorf Klaus-Bungert-Straße, 51.2737, 6.76894
+Porsche DE-Estenfeld Porschestraße, 49.8403, 10.0096
+Porsche DE-Freiburg Basler Straße, 47.985, 7.8237267327881
+Porsche DE-Fulda Kohlhäuser Straße, 50.5345, 9.6821966680908
+Porsche DE-Garmisch Partenkirchen An der Zugspitze, 47.479158457184, 11.055158457184
+Porsche DE-Hagen Florianstraße, 51.3748, 7.5444378125
+Porsche DE-Hannover Podbielskistraße, 52.3967, 9.76703
+Porsche DE-Hilzingen Untere Gießwiesen, 47.7603, 8.7896069880676
+Porsche DE-Hockenheim Am Motodrom, 49.32784447355, 8.5700276117865
+Porsche DE-Kaiserslautern Europaallee, 49.453266536713, 7.8161602339172
+Porsche DE-Kempten Georg-Krug-Straße, 47.7377, 10.3374
+Porsche DE-Kiel Projensdorfer Straße, 54.3478, 10.1298
+Porsche DE-Kleinmachnow Albert-Einstein-Ring, 52.4061, 13.188633731842
+Porsche DE-Köln Fröbelstraße, 50.9442, 6.91637
+Porsche DE-Landau in der Pfalz Hermann Staudinger Straße, 49.1928, 8.1430864323425
+Porsche DE-Lörrach Eisenbahnstraße, 47.6318, 7.68351
+Porsche DE-Ludwigsburg Porschestraße, 48.9187, 9.15016
+Porsche DE-Lüneburg Lüner Heide, 53.2719, 10.4244
+Porsche DE-Mannheim Elsa-Brändström-Straße, 49.4498, 8.5673166177368
+Porsche DE-Moers Am Schürmannshütt 1a +, 51.4532, 6.6103635415649
+Porsche DE-München Drygalski-Allee, 48.0936, 11.5036
+Porsche DE-München Schleibingerstraße , 48.1293, 11.5909
+Porsche DE-Münster Weseler Straße, 51.9248, 7.57308
+Porsche DE-Nürnberg Erlanger Straße, 49.48535, 11.0589
+Porsche DE-Offenburg Otto-Hahn-Straße, 48.4831, 7.9379
+Porsche DE-Oldenburg Nadorster Straße, 53.1608, 8.22354
+Porsche DE-Osnabrück Blumenhaller Weg, 52.2646, 8.00935
+Porsche DE-Pforzheim Kieselbronner Straße, 48.9108, 8.7197964685059
+Porsche DE-Recklinghausen Schmalkalder Straße, 51.5979, 7.2463036069489
+Porsche DE-Rostock Ferdinand Porsche Straße, 54.0327, 12.0998
+Porsche DE-Schwäbisch Gmünd Ferdinand-Porsche-Weg, 48.7915, 9.7722198827362
+Porsche DE-Siegen Marienhütte, 50.8527, 8.000793125
+Porsche DE-Sinzheim Landstraße, 48.7668, 8.17029
+Porsche DE-Soest Am Bohnenpfad, 51.5528, 8.09877
+Porsche DE-Solingen Schlagbaumer Straße, 51.1814, 7.08109
+Porsche DE-Stuttgart Im Birkenwald, 48.8312, 9.14674
+Porsche DE-Stuttgart Siemensstr., 48.8108, 9.1813233011521
+Porsche DE-Villingen-Schwenningen Goldenbühlstraße, 48.0661, 8.4581466567993
+Porsche DE-Weingarten Hähnlehofstraße, 47.7979, 9.62116
+Porsche DE-Weissach Porschestraße, 48.8509, 8.8998800385284
+Porsche DE-Wettenberg Lahnwegsberg, 50.6172, 8.66242
+Porsche DE-Wiesbaden Mainzer Straße, 50.0559, 8.25723
+Porsche DE-Willich Jakob-Kaiser-Str., 51.2721, 6.51569
+Porsche DE-Wuppertal Porschestraße, 51.3053, 7.25279
+
 Recharge FI-Sodankylä, 67.431695,26.57509
 
 REWE DE-Bremen, 53.136455, 8.739926

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -1341,65 +1341,194 @@ Tesla Service Center US-Palo Alto, 37.394287, -122.150604
 Aldi DE-Aachen Neuenhofstraße, 50.760742, 6.152673
 Aldi DE-Aachen Ronder Weg, 50.817262, 6.065772
 Aldi DE-Aachen Süsterfeldstraße, 50.786292, 6.063822
+Aldi DE-Allershausen Mühlenstraße, 48.429667, 11.580861
+Aldi DE-Altötting Mühldorfer Straße, 48.226528, 12.657944
+Aldi DE-Alzey Karl-Heinz-Kipp-Straße, 49.7455, 8.140417
 Aldi DE-Ansbach, 49.293465,10.603837, 20
+Aldi DE-Augsburg Edisonstraße, 48.346333, 10.881444
+Aldi DE-Augsburg Steinerne Furt, 48.393611, 10.925278
+Aldi DE-Augsburg Weiherstraße, 48.388611, 10.883306
 Aldi DE-Bad Camberg, 50.296238, 8.254424
+Aldi DE-Baden-Baden Schwarzwaldstraße, 48.776975, 8.213665
+Aldi DE-Bamberg Münchner Ring, 49.884222, 10.915056
+Aldi DE-Bergisch Gladbach Am Stockbrunnen, 50.963611, 7.164361
+Aldi DE-Bergisch Gladbach-Gronau Kradepohlsmühlenweg, 50.982722, 7.104194
 Aldi DE-Bernau am Chiemsee, 47.825325, 12.384109
-Aldi DE-Böblingen, 48.685646, 8.993401
+Aldi DE-Bogen Bärndorf, 48.913528, 12.728222
+Aldi DE-Bonn-Beuel Gartenstr., 50.750278, 7.130667
+Aldi DE-Bonn-Beuel Maarstraße, 50.73775, 7.131111
+Aldi DE-Bonn-Lannesdorf Drachenburgstraße, 50.667667, 7.18025
+Aldi DE-Bottrop Horster Str., 51.524417, 6.932389
 Aldi DE-Böblingen Süd Bahnhof, 48.677525,9.011909
+Aldi DE-Böblingen, 48.685646, 8.993401
+Aldi DE-Dannstadt Riedstraße, 49.434278, 8.317528
+Aldi DE-Darmstadt  Eschollbrücker Straße, 49.859889, 8.63675
 Aldi DE-Darmstadt-Arheilgen, 49.906825,8.648799
 Aldi DE-Dinslaken, 51.560813,6.741382, 20
+Aldi DE-Dormagen-Horrem Mathias-Giesen-Straße, 51.094778, 6.816278
+Aldi DE-Dormagen-Nievenheim An der Sausweide, 51.120194, 6.76875
+Aldi DE-Duisburg Rathausallee, 51.3975, 6.663528
+Aldi DE-Duisburg-Duissern Aakerfährstraße, 51.440111, 6.782694
+Aldi DE-Duisburg-Duissern Auf der Höhe, 51.441972, 6.760806
+Aldi DE-Duisburg-Großenbaum Großenbaumer Allee, 51.371083, 6.778722
+Aldi DE-Duisburg-Hamborn Schlachthofstraße, 51.503056, 6.783889
+Aldi DE-Duisburg-Laar Friedrich-Ebert-Straße, 51.462389, 6.733861
+Aldi DE-Duisburg-Wanheimerort Kulturstraße, 51.406918, 6.757777
+Aldi DE-Düsseldorf Aachener Straße, 51.199167, 6.771111
+Aldi DE-Düsseldorf Angermunder Straße , 51.330028, 6.781
+Aldi DE-Düsseldorf Erkrather Straße , 51.218722, 6.816278
+Aldi DE-Düsseldorf Gaußstraße, 51.227278, 6.818222
+Aldi DE-Düsseldorf Heerdter Landstraße, 51.231167, 6.711333
+Aldi DE-Düsseldorf Nürnberger Straße, 51.171278, 6.860667
 Aldi DE-Echterdingen, 48.695676,9.168745
 Aldi DE-Eisingen, 49.761243,9.845965, 20
+Aldi DE-Elsenfeld Bahnhofstraße, 49.841579, 9.156343
+Aldi DE-Emmerich Bahnhofstraße, 51.833444, 6.252111
+Aldi DE-Emmerich am Rhein Moritz-von-Nassau-Straße, 51.846528, 6.234389
+Aldi DE-Erlangen  Henkestraße, 49.593528, 11.018139
 Aldi DE-Erlangen Gundstraße 2,49.583525, 10.965227,10
+Aldi DE-Ettenheim Tullastraße, 48.260806, 7.804972
+Aldi DE-Euskirchen Stresemannstraße, 50.667139, 6.806361
+Aldi DE-Frankfurt Heddernheim Olof-Palme-Straße, 50.1665, 8.644111
+Aldi DE-Frankfurt West-Höchster Straße, 50.091944, 8.503306
+Aldi DE-Frankfurt am Main Lärchenstraße, 50.099306, 8.586222
+Aldi DE-Freiburg Heckerstraße, 47.989059, 7.800174
+Aldi DE-Freudenberg  Weibeweg, 50.904722, 7.886667
 Aldi DE-Friedberg, 48.406611, 10.951264, 10
-Aldi DE-Fürth, 49.454280, 11.001354, 10
+Aldi DE-Fußgönheim Am Weisenheimer Weg , 49.467667, 8.286278
+Aldi DE-Fürth Karolinenstraße, 49.467472, 10.995139
 Aldi DE-Fürth Magazinstraße 61, 49.454155, 11.001397, 10
+Aldi DE-Fürth, 49.454280, 11.001354, 10
+Aldi DE-Griesheim Flughafenstraße, 49.860556, 8.590778
+Aldi DE-Heidelberg Im Schuhmachergewann, 49.426194, 8.639611
+Aldi DE-Heidelberg Pleikartsförster Straße, 49.378139, 8.664111
+Aldi DE-Heilbronn Gaswerkstr., 49.150278, 9.216667
+Aldi DE-Heilbronn Stuttgarter Straße, 49.13355, 9.226808
 Aldi DE-Heiligenroth Industriegebiet, 50.448115, 7.845324
+Aldi DE-Heusweiler Trierer Straße, 49.346139, 6.935361
 Aldi DE-Hünxe, 51.642562, 6.758384
+Aldi DE-Ingolstadt Despag-Straße, 48.776139, 11.451806
+Aldi DE-Ingolstadt Münchener Straße, 48.735361, 11.43925
 Aldi DE-Kaarst, 51.218956, 6.633498
+Aldi DE-Kaiserslautern  Königstraße, 49.437306, 7.757167
+Aldi DE-Karlsdorf Erich-Keßler-Straße, 49.140139, 8.55325
+Aldi DE-Karlsruhe  Hohenzollernstraße, 48.993889, 8.385222
+Aldi DE-Karlsruhe Borsigstraße, 49.021028, 8.355139
+Aldi DE-Karlsruhe-Neureut Lorbeerweg, 49.037333, 8.391694
 Aldi DE-Kelsterbach, 50.058617, 8.521086
-Aldi DE-Krefeld Hafelstraße,51.323613,6.605946,10
+Aldi DE-Kirchentellinsfurt Wannweiler Straße , 48.527278, 9.142444
 Aldi DE-Kirchheim unter Teck, 48.652609, 9.45985
+Aldi DE-Kirchheimbolanden Woogmorgen, 49.66025, 8.021083
+Aldi DE-Kirkel Konrad-Zuse-Straße, 49.302722, 7.263639
+Aldi DE-Kirrweiler Staatsstraße, 49.289976, 8.14087
 Aldi DE-Koblenz-Moselweiß, 50.357783, 7.575242
+Aldi DE-Konstanz Oberlohnstraße, 47.674667, 9.158111
+Aldi DE-Krefeld Hafelstraße,51.323613,6.605946,10
+Aldi DE-Köln Ossendorf Mathias-Brüggen-Str., 50.983306, 6.887333
 Aldi DE-Köln, 50.906526, 6.934391
+Aldi DE-Köln-Bilderstöckchen  Robert-Perthel-Straße, 50.984306, 6.913556
+Aldi DE-Köln-Marsdorf Emmy-Noether-Straße, 50.91791, 6.84983
+Aldi DE-Königsfeld Peterzeller Straße, 48.135667, 8.420389
 Aldi DE-Königshofen, 49.542487, 9.733833
+Aldi DE-Kürnach Wachtelberg, 49.841167, 10.018056
+Aldi DE-Lahr Dr. Georg-Schaeffler-Straße, 48.347569, 7.82163
 Aldi DE-Langen,49.994933,8.677451,10
+Aldi DE-Laufenburg Laufenpark, 47.565389, 8.074583
 Aldi DE-Leonberg, 48.798462, 8.999601
+Aldi DE-Leverkusen-Fixheide Schlebuscher Straße, 51.05, 7.013389
+Aldi DE-Leverkusen-Opladen Bonner Straße, 51.067417, 6.990194
+Aldi DE-Lindau Von-Behring-Str., 47.550611, 9.722111
 Aldi DE-Lorsch, 49.65359, 8.555596
+Aldi DE-Ludwigsburg Martin-Luther-Straße, 48.891194, 9.181389
 Aldi DE-Ludwigsburg, 48.879803,9.218476,20
 Aldi DE-Mainaschaff, 49.986603, 9.084044, 10
+Aldi DE-Mainz-Hechtsheim Johannes-Kepler-Straße, 49.964167, 8.2625
+Aldi DE-Mainz-Neustadt  Hattenbergstraße, 50.013583, 8.247972
+Aldi DE-Mannheim Floßwörthstraße, 49.458041, 8.503102
+Aldi DE-Mannheim Untermühlaustraße, 49.511641, 8.47124
 Aldi DE-Marktrodach, 50.255932, 11.396508
-Aldi DE-Merchweiler, 49.349395, 7.050618
 Aldi DE-Memmingen, 47.972183, 10.184331
+Aldi DE-Merchweiler, 49.349395, 7.050618
+Aldi DE-Merzig Rieffstraße, 49.436861, 6.632111
+Aldi DE-Moers Bahnhofstraße, 51.416611, 6.5935
+Aldi DE-Moers Drennesweg, 51.477278, 6.60475
+Aldi DE-Moers Orsoyer Allee, 51.48, 6.63342
+Aldi DE-Moers Uerdinger Straße, 51.445778, 6.635028
+Aldi DE-Mönchengladbach Bröseweg, 51.207972, 6.445583
+Aldi DE-Mönchengladbach Hofstraße, 51.185222, 6.451861
+Aldi DE-Mönchengladbach Stapper Weg, 51.138167, 6.444333
+Aldi DE-Mühlhausen - Ehingen Hohenkräher Brühl, 47.8035, 8.824861
+Aldi DE-Mülheim an der Ruhr Heidestraße, 51.451139, 6.849861
+Aldi DE-Mülheim an der Ruhr Werdener Weg, 51.420806, 6.895417
+Aldi DE-München  Landsberger Straße, 48.145056, 11.485556
+Aldi DE-München Großhaderner Straße, 48.120528, 11.481722
+Aldi DE-München-Mittelsendling Zielstattstraße, 48.1015, 11.525389
+Aldi DE-München-Moosach Dachauer Straße, 48.188771, 11.502979
+Aldi DE-München-Neuperlach Maximilian-Kolbe-Allee, 48.088417, 11.639139
 Aldi DE-München-Taufkirchen, 48.056601,11.603513
+Aldi DE-München-Trudering Bognerhofweg, 48.123056, 11.66975
 Aldi DE-München-Unternaching, 48.06821,11.619124
+Aldi DE-Nauheim Mainzer Landstraße, 49.940706, 8.445407
+Aldi DE-Nettersheim-Zingsheim Nürburgstraße, 50.508278, 6.658556
+Aldi DE-Nettetal Poststraße, 51.325722, 6.200361
+Aldi DE-Neu-Isenburg Rathenaustrasse , 50.042056, 8.691111
+Aldi DE-Neu-Ulm Adenauerstraße, 48.409709, 10.067371
+Aldi DE-Neuenburg Colmarer Straße, 47.817417, 7.556416
+Aldi DE-Neuss-Holzheim Maximilianstraße, 51.163833, 6.666167
+Aldi DE-Neuss-Weißenberg Normannenstraße, 51.216806, 6.682528
+Aldi DE-Niederwerrn Schweinfurter Straße, 50.058361, 10.188778
+Aldi DE-Nürnberg  Ostendstraße, 49.456361, 11.121444
 Aldi DE-Nürnberg Geisseestr., 49.434974, 11.041029
-Aldi DE-Nürnberg Regensburgerstr., 49.435626,11.122648
+Aldi DE-Nürnberg Grolandstraße, 49.465417, 11.076167
+Aldi DE-Nürnberg Lübener Straße, 49.410389, 11.14
 Aldi DE-Nürnberg Münchenerstr., 49.400938, 11.117048
+Aldi DE-Nürnberg Regensburgerstr., 49.435626,11.122648
 Aldi DE-Nürnberg Wiesbadenerstr., 49.522306, 11.007037
+Aldi DE-Nürnberg-Herpersdorf An der Radrunde, 49.372028, 11.081889
+Aldi DE-Oberhausen Mellinghofer Str., 51.479778, 6.88525
+Aldi DE-Passau Neuburger Straße, 48.55951, 13.422341
+Aldi DE-Pentling Hohengebrachinger Straße, 48.980444, 12.067472
 Aldi DE-Petersberg, 50.553999, 9.712663
-Aldi DE-Piding, 47.75726,12.898753
 Aldi DE-Pforzheim, 48.902632, 8.663465
+Aldi DE-Piding, 47.75726,12.898753
+Aldi DE-Pulheim  Steinstraße, 50.995333, 6.800583
 Aldi DE-Putzbrunn, 48.081192,11.692257
 Aldi DE-Rastatt, 48.85911, 8.238882, 20
+Aldi DE-Raubling  Friedrich-Fuckel-Straße, 47.791528, 12.113111
 Aldi DE-Rauenberg, 49.27325,8.695788, 20
-Aldi DE-Reutlingen Karl-Henschel-Straße, 48.495184, 9.158096, 20
-Aldi DE-Reutlingen Heubergstraße, 48.512494, 9.217845, 20
+Aldi DE-Rehlingen Im Dürrfeldslach, 49.372306, 6.68625
 Aldi DE-Reutlingen Föhrstraße, 48.502283, 9.207886, 20
+Aldi DE-Reutlingen Heubergstraße, 48.512494, 9.217845, 20
+Aldi DE-Reutlingen Karl-Henschel-Straße, 48.495184, 9.158096, 20
 Aldi DE-Rotheidlen, 47.731574,9.698803,20
+Aldi DE-Saarbrücken Hirtenwies, 49.218833, 6.968444
+Aldi DE-Sandhausen Gottlieb-Daimler-Straße, 49.340389, 8.667
+Aldi DE-Schweich In den Schlimmfuhren, 49.82, 6.746639
 Aldi DE-Seeheim, 49.774399,8.636451
+Aldi DE-Selb Weißenbacher Straße, 50.168611, 12.107806
+Aldi DE-Sinn In der Au, 50.652583, 8.325472
+Aldi DE-Stromberg Friedrichsheck, 49.949028, 7.786028
 Aldi DE-Stuttgart Bottroper Straße, 48.81756,9.214898,20
 Aldi DE-Stuttgart Feuerbach,48.810917,9.168455,20
 Aldi DE-Stuttgart Galileistraße,48.72103,9.119991,20
 Aldi DE-Stuttgart Sophie-Tschorn-Straße, 48.817315,9.23782
 Aldi DE-Stuttgart Westbahnhof, 48.769497,9.142045, 20
+Aldi DE-Trier Zurmaiener Straße, 49.773944, 6.667306
+Aldi DE-Troisdorf Siebengebirgsallee, 50.807083, 7.174444
 Aldi DE-Ulm, 48.400669, 9.971991
+Aldi DE-Unkel Am Hohen Weg, 50.594556, 7.217889
 Aldi DE-Unterhaching, 48.059676, 11.633342, 20
+Aldi DE-Weil-Friedlingen Alte Straße , 47.599361, 7.599056
 Aldi DE-Weilimdorf, 48.821298,9.098822
 Aldi DE-Wetzendorf, 49.496251, 11.262201
 Aldi DE-Wiesbaden Hagenauerstr., 50.048155, 8.217388
 Aldi DE-Wiesbaden Siemensstraße, 50.059017,8.338261, 20
+Aldi DE-Wiesbaden-Dotzheim Am Hang, 50.079333, 8.201861
+Aldi DE-Wittlich Gottlieb-Daimler-Straße, 49.980806, 6.903278
+Aldi DE-Wölfersheim-Berstadt Benzstraße, 50.422056, 8.856306
 Aldi DE-Wörnitz, 49.2593663, 10.241920
+Aldi DE-Zweibrücken Etzelweg, 49.227083, 7.355306
+Aldi DE-Öhringen  Steinsfeldle, 49.189917, 9.495556
 
 Allego DE-Achern Am Achernsee 1 , 48.64082809512, 8.0373276195192
 Allego DE-Achim Fritz-Lieken-Eck 6 , 53.016658, 9.033777

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -8571,6 +8571,111 @@ TotalEnergies NL-Poort Van Veghel,51.59952745,5.51673214,80
 TotalEnergies NL-Schiedam,51.93023763,4.403939056,80
 TotalEnergies NL-Vliedberg,51.484617,3.850016,80
 
+Volkswagen DE-Aichtal Uferstraße 10 , 48.625343, 9.261603
+Volkswagen DE-Alfeld (Leine) Senator-Behrens-Straße 6 , 51.992064, 9.83923
+Volkswagen DE-Altenberge Siemensstraße 2 , 52.043829, 7.455634
+Volkswagen DE-Auerbach/Vogtland Werkstraße 6 , 50.521644, 12.380602
+Volkswagen DE-Bad Hersfeld An d. Haune 2 , 50.861375, 9.722035
+Volkswagen DE-Berlin Siegfriedstraße 150 , 52.528479, 13.499556
+Volkswagen DE-Bernau bei Berlin Schwanebecker Chaussee 21b , 52.671028, 13.585413
+Volkswagen DE-Bernburg (Saale) Hallesche Landstraße 110 , 51.770731, 11.7477
+Volkswagen DE-Biberach Ahfeldstraße 2 , 48.334841, 8.031822
+Volkswagen DE-Bitburg Dieselstraße 18 , 49.950853, 6.531852
+Volkswagen DE-Blomberg Auf den Kreuzen 12-14 , 51.934522, 9.088324
+Volkswagen DE-Bonn Königswinterer Str. 444 , 50.721855, 7.154139
+Volkswagen DE-Borgholzhausen Industriestraße 1 , 52.0854436875, 8.267746125
+Volkswagen DE-Bottrop Pelsstraße 35 , 51.611065, 6.929183
+Volkswagen DE-Braunschweig Schmalbachstraße 1 , 52.297178669643, 10.514571421871
+Volkswagen DE-Breitscheid Heisterberger Weg 3 , 50.665025, 8.172521
+Volkswagen DE-Buchholz in der Nordheide Lüneburger Str. 9 , 53.324369, 9.882723
+Volkswagen DE-Butzbach Große Wendelstraße 67 , 50.434763723823, 8.677698012177
+Volkswagen DE-Chemnitz Limbacher Straße 110-112 , 50.836424397159, 12.890689361378
+Volkswagen DE-Crailsheim Ludwig-Erhard-Straße 120 , 49.134731, 10.036892
+Volkswagen DE-Dachau Münchner Straße 87 , 48.245405, 11.448336
+Volkswagen DE-Dallgow-Döberitz Wilmsstraße 120 , 52.551297, 13.056334
+Volkswagen DE-Detmold Lise-Meitner-Straße 15 , 51.932865, 8.920126
+Volkswagen DE-Dietersheim Am Baumgarten 3 , 49.558419, 10.54166
+Volkswagen DE-Dillingen an der Donau Gewerbegebiet X , 48.585185, 10.5091325
+Volkswagen DE-Doberlug-Kirchhain Bahnhofsallee 1 , 51.612555224154, 13.554692083951
+Volkswagen DE-Eberhardzell Biberacher Str. 20 , 48.000146, 9.891401
+Volkswagen DE-Ellwangen (Jagst) In d. Au 4 , 48.953979, 10.118149
+Volkswagen DE-Ettlingen Gutenbergstraße 2 , 48.947781, 8.379761
+Volkswagen DE-Fritzlar Im Wehrengrund 1 , 51.142787, 9.275586
+Volkswagen DE-Fuldatal Niedervellmarsche Straße 25a , 51.350835082603, 9.521484881482
+Volkswagen DE-Garmisch-Partenkirchen Münchner Str. 100 , 47.507747, 11.105271
+Volkswagen DE-Gifhorn Wolfsburger Str. 3 , 52.4629, 10.545884
+Volkswagen DE-Gladenbach Bahnhofstraße , 50.7661, 8.583046
+Volkswagen DE-Groß-Gerau Mainzer Str. 72 , 49.92397225, 8.4723005
+Volkswagen DE-Großschirma Wasserturmstraße 15 , 51.031926, 13.302538
+Volkswagen DE-Hannover Ben-Pon-Platz , 52.417052375679, 9.6539234746058
+Volkswagen DE-Hannover Grambartstraße 29 , 52.408, 9.704224
+Volkswagen DE-Hannover Mecklenheidestraße 74 , 52.416324, 9.667393
+Volkswagen DE-Hausen Fladunger Str. 29 , 50.508579027084, 10.130974947006
+Volkswagen DE-Herford Mindener Str. 44 , 52.121821, 8.681255
+Volkswagen DE-Hirschberg an der Bergstraße Landstraße , 49.514523, 8.656261
+Volkswagen DE-Hoyerswerda Str. A 1 , 51.430261, 14.277824
+Volkswagen DE-Hünfeld Fuldaer Str. 8 , 50.669198, 9.762847
+Volkswagen DE-Hünfeld Hersfelder Str. 30 , 50.687574, 9.756091
+Volkswagen DE-Jülich An d. Vogelstange 93B , 50.909365, 6.358766
+Volkswagen DE-Kamenz An der Windmühle 3 , 51.284408, 14.094724
+Volkswagen DE-Karlstadt Gewerbegebiet Am Hammersteig , 49.974258875, 9.7702824375
+Volkswagen DE-Kempten (Allgäu) Calgeerstraße 7 , 47.714006, 10.316084
+Volkswagen DE-Kempten (Allgäu) Heisinger Str. 2 , 47.760395, 10.332671
+Volkswagen DE-Köln Robert-Perthel-Straße 65 - 69 , 50.989513, 6.907349
+Volkswagen DE-Landsberg am Lech Graf-Zeppelin-Str.2 , 48.067674, 10.860956
+Volkswagen DE-Leutkirch im Allgäu Im Ösch 8 , 47.796322, 10.016311
+Volkswagen DE-Lüchow Drawehner Straße , 52.964914, 11.148901
+Volkswagen DE-Luckenwalde Brandenburger Str. 36 , 52.095775, 13.157239
+Volkswagen DE-Meißen Berghausstraße 2A , 51.174569, 13.497208
+Volkswagen DE-Memmingen Münchner Str. 81 , 47.996373, 10.197552
+Volkswagen DE-Mengen Meßkircher Str. 39 , 48.043282, 9.321406
+Volkswagen DE-Moers Rheinberger Str. 61 , 51.45772, 6.63124
+Volkswagen DE-Mühlacker Industriestraße 27 , 48.953048, 8.851331
+Volkswagen DE-Mühlhausen/Thüringen Kasseler Str. 45-47 , 51.203795997742, 10.438102000305
+Volkswagen DE-Neuburg an der Donau Am Schwalbanger , 48.725682, 11.191323
+Volkswagen DE-Neumarkt in der Oberpfalz Nürnberger Str. 45 , 49.289555, 11.436363
+Volkswagen DE-Neuss Jülicher Landstraße 41-43 , 51.187611, 6.685147
+Volkswagen DE-Neuwied Stettiner Str. 4-6 , 50.434922038152, 7.4859556156794
+Volkswagen DE-Nordhausen Helmestraße 111 , 51.476644, 10.807627
+Volkswagen DE-Oelde Westrickweg 2 , 51.823674, 8.12624
+Volkswagen DE-Öhringen Rudolf-Diesel-Straße 1 , 49.200257, 9.47635
+Volkswagen DE-Oldenburg Bremer Heerstr., 53.129176, 8.22899
+Volkswagen DE-Oldenburg Rudolf-Diesel-Str. 32, 53.124209, 8.22772
+Volkswagen DE-Osann-Monzel Moseltalstraße 40 , 49.918641, 6.952191
+Volkswagen DE-Osnabrück Karmannstraße 1 , 52.263978999996, 8.0817496666824
+Volkswagen DE-Pfalzgrafenweiler Daimlerstraße 20 , 48.532878, 8.571777
+Volkswagen DE-Pritzwalk Fritz-Reuter-Straße 6 , 53.135352, 12.177526
+Volkswagen DE-Rellingen Stawedder 17-21 , 53.644005, 9.835121
+Volkswagen DE-Rodeberg Mühlhäuser Landstraße 4 , 51.21136125, 10.3309175
+Volkswagen DE-Saarlouis Wallerfanger Straße , 49.32006, 6.733464
+Volkswagen DE-Salzgitter Industriestraße Nord , 52.183035, 10.444337
+Volkswagen DE-Salzwedel An der Ritzer Brücke 5 , 52.852061000137, 11.181975000385
+Volkswagen DE-Scheinfeld Nürnberger Str. 1 , 49.663344, 10.460448
+Volkswagen DE-Schermbeck Kapellenweg 42 , 51.684868, 6.88060575
+Volkswagen DE-Schieder-Schwalenberg Am Zollstock 6 , 51.893803, 9.166867
+Volkswagen DE-Schmallenberg Auf der Lake 5 , 51.156734855417, 8.2939785718082
+Volkswagen DE-Schwäbisch Gmünd Bänglesäcker 2 , 48.834606, 9.821913
+Volkswagen DE-Schwarzenfeld Böttgerstraße 50 , 49.391537671826, 12.127816590153
+Volkswagen DE-Schweinfurt Stockholmstraße 2 , 50.011766, 10.215193
+Volkswagen DE-Soltau Herzog-Bernd-Straße 3 , 52.986074, 9.857654
+Volkswagen DE-Steffenberg Lahnstraße 34 , 50.852077, 8.465569
+Volkswagen DE-Stralsund Alte Rostocker Str. 9 , 54.306984, 13.075038
+Volkswagen DE-Timmendorfer Strand Vogelsang 6-8 , 53.987189, 10.769813
+Volkswagen DE-Trier Monaiser Str. 3 , 49.721698, 6.590809
+Volkswagen DE-Trossingen In Steppach 9-11 , 48.076042233444, 8.6240010718291
+Volkswagen DE-Überlingen Hauptstraße 37 , 47.802296, 9.238275
+Volkswagen DE-Varel Am Tannenkamp 91 , 53.368855, 8.126847
+Volkswagen DE-Waldshut-Tiengen Porschestraße 1 , 47.629532053215, 8.2673388063306
+Volkswagen DE-Weissach Porschestraße 911 , 48.845139, 8.9045
+Volkswagen DE-Welzheim Starenweg 30 , 48.87343, 9.626847
+Volkswagen DE-Wertingen Industriestraße 4 , 48.561628, 10.687901
+Volkswagen DE-Wiesbaden Georg-Beatzel-Straße 17 , 50.029625, 8.284691
+Volkswagen DE-Wolfsburg Berliner Ring 2 , 52.429667, 10.769897
+Volkswagen DE-Wurzen Schiemannstraße 2 , 51.385319768884, 12.73903904992
+Volkswagen DE-Zellingen Stützenbergstr.1 , 49.901148, 9.820156
+Volkswagen DE-Zwickau Glauchauer Straße , 50.788723, 12.489462
+Volkswagen DE-Zwickau Schubertstraße , 50.746634, 12.478944
+
 AT Eugendorf Center, 47.860013,13.126857,20
 AT Hartberg Hauptplatz, 47.281412,15.968967, 20
 AT Mistelbach Autohaus Wiesinger, 48.557928,16.562185, 10

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -2661,6 +2661,176 @@ Comfortcharge DE-Zusmarshausen Arnulfstraße, 48.39936, 10.5991
 Comfortcharge DE-Zwickau Bülaustr., 50.715631240234, 12.452783203125
 Comfortcharge DE-Zwickau Scheffelstraße, 50.73374, 12.5068
 
+Compleo DE-Ahrensburg Kurt-Fischer-Str., 53.683325, 10.261508
+Compleo DE-Aichach Freisinger Straße, 48.45944637207, 11.14816736969
+Compleo DE-Altenburg , 50.977363, 12.433845
+Compleo DE-Arnsberg Niedereimerfeld, 51.423124, 8.034265
+Compleo DE-Augsburg Nürnberger Straße, 48.413944985243, 10.854806585016
+Compleo DE-Augsburg Schaezlerstraße, 48.36570727832, 10.892433025146
+Compleo DE-Baar Aichacher Straße, 48.587921, 10.9607
+Compleo DE-Bad Lauchstädt Ahornstr., 51.385176, 11.883146
+Compleo DE-Bad Oldesloe Lily-Braun Str., 53.80242471875, 10.4028295625
+Compleo DE-Bad Salzuflen Uferstraße, 52.066956791396, 8.7545590031242
+Compleo DE-Bad Saulgau Moosheimer Str., 48.02184, 9.49616
+Compleo DE-Bannewitz An de Zschauke, 51.001175, 13.720209
+Compleo DE-Bärenstein Sächsischer Platz, 50.498622, 13.028103
+Compleo DE-Beckum Bauknechtstraße / Obere, 51.772132, 8.032474
+Compleo DE-Berlin Falkenseer Chaussee, 52.548928, 13.178883
+Compleo DE-Bielefeld Brockhagener Straße, 51.987573, 8.483534
+Compleo DE-Bielefeld Föhrenstr., 51.96945, 8.46246
+Compleo DE-Bielefeld Werningshof, 52.039039, 8.595272
+Compleo DE-Bissendorf Gewerbepark, 52.241772, 8.137805
+Compleo DE-Borgentreich Zum Dreschplatz, 51.542406, 9.204267
+Compleo DE-Borna , 51.127362, 12.506541
+Compleo DE-Borna Gewerbepark Borna-Ost, 51.134396, 12.509869
+Compleo DE-Borsdorf Otto-von-Guericke-Str. 1, 51.354464, 12.542412
+Compleo DE-Chemnitz Chemnitztalstr., 50.858112958028, 12.927022916056
+Compleo DE-Chemnitz-Röhrsdorf Ringstraße, 50.865, 12.864917
+Compleo DE-Cottbus Thiemstr., 51.74868, 14.328070000065
+Compleo DE-Detmold , 51.941113, 8.874645
+Compleo DE-Detmold Hornsche Str., 51.929538, 8.886029
+Compleo DE-Dillingen/Saar , 49.34676, 6.70933
+Compleo DE-Dillingen/Saar Werkstraße, 49.356661994141, 6.7341319868164
+Compleo DE-Dingolfing Karl-Dompert-Straße, 48.643673, 12.470234
+Compleo DE-Dingolfing Laaberstraße, 48.640707340016, 12.492254996689
+Compleo DE-Eibenstock Karlsbader Str., 50.492818, 12.601901
+Compleo DE-Eisenach Stedtfelder Strasse, 51.0101925, 10.2605675
+Compleo DE-Enge-Sande Lecker Straße, 54.740504, 8.955594
+Compleo DE-Falkenberg Mühlberger Straße, 51.586557157748, 13.235851688995
+Compleo DE-Freiberg Frauensteinerstr., 50.908212, 13.363178
+Compleo DE-Freiberg Hornstraße, 50.916412, 13.347121
+Compleo DE-Friedberg , 48.353209, 10.980607
+Compleo DE-Friedberg Balthasar-Schaller-Straße, 48.365139, 10.950705
+Compleo DE-Friedrichshafen Eckenerstr., 47.65255, 9.48451
+Compleo DE-Friedrichshafen Kornblumenstr., 47.668117532931, 9.4880559155178
+Compleo DE-Geisenheim Winkeler Str., 49.985174, 7.969636
+Compleo DE-Gelsenkirchen Cranger Str., 51.57541175, 7.0598274375
+Compleo DE-Gelsenkirchen Kurt-Schumacher-Str., 51.523517, 7.08852
+Compleo DE-Germersheim Hafenstr., 49.232119, 8.369351
+Compleo DE-Geschendorf , 53.92218, 10.45442
+Compleo DE-Gescher Schüringsweg, 51.942794, 7.025359
+Compleo DE-Gladbeck Karl-Schneider-Straße, 51.572980990215, 6.9713181095895
+Compleo DE-Gladbeck Schillerstr., 51.57499, 6.99284
+Compleo DE-Glauchau Rudolf-Breitscheid-Straße, 50.819662, 12.550579
+Compleo DE-Glauchau Sachsenallee, 50.827162, 12.519897
+Compleo DE-Gmund am Tegernsee Schwärzenbach, 47.751908, 11.755217
+Compleo DE-Graben Landsberger Straße, 48.198827949219, 10.854684033203
+Compleo DE-Grimma Wedniger Str., 51.256387097422, 12.737224707735
+Compleo DE-Großräschen Seestr., 51.576256, 14.010139
+Compleo DE-Günthersdorf Saalepark Nova Eventis, 51.346100163436, 12.176066580744
+Compleo DE-Günzburg Siemensstraße, 48.459915419446, 10.279829838538
+Compleo DE-Haldensleben , 52.291476, 11.413304
+Compleo DE-Halle (Saale) Magdeburger Str., 51.481894600007, 11.982759630763
+Compleo DE-Herne Am Neumarkt, 51.54101, 7.224568
+Compleo DE-Herne Grenzweg, 51.54062924996, 7.2076349700147
+Compleo DE-Herten Doncaster Platz, 51.57254, 7.14832
+Compleo DE-Herzberg Wilhelm-Pieck-Ring, 51.693026, 13.228868
+Compleo DE-Hildburghausen Kaltenbronner Weg, 50.421258, 10.751844
+Compleo DE-Hösbach BMW Hermann Arnold GmbH - Industriestr., 50.006833, 9.220806
+Compleo DE-Idar - Oberstein Hauptstraße, 49.71343, 7.31209
+Compleo DE-Illertissen Industriestraße, 48.206462, 10.106154
+Compleo DE-Iserlohn Fingerhutsmühle, 51.364622, 7.612209
+Compleo DE-Iserlohn Mendener Straße, 51.37518, 7.704853
+Compleo DE-Iserlohn Seeuferstr., 51.387449, 7.712014
+Compleo DE-Kabelsketal Industriestr., 51.443746, 12.133108
+Compleo DE-Kaufering Viktor-Frankl-Straße, 48.08022, 10.85504
+Compleo DE-Kirchberg Hartmannsdorfer Straße, 50.615402, 12.529442
+Compleo DE-Kleinaitingen Rathausstraße, 48.217945031804, 10.84207283714
+Compleo DE-Klostermansfeld Bahnhofstr., 51.575588352539, 11.494210581055
+Compleo DE-Kolkwitz Annahofer Graben, 51.717873844487, 14.288493135833
+Compleo DE-Konz Wilde Acht, 49.695, 6.56544
+Compleo DE-Krumbach (Schwaben) Erwin-Bosch-Ring, 48.237185, 10.373022
+Compleo DE-Landau Am Schänzel, 49.209564, 8.118001
+Compleo DE-Landsberg am Lech Sandauer Straße, 48.05452, 10.87698
+Compleo DE-Langenargen Untere Seestraße, 47.598136, 9.538098
+Compleo DE-Langenwetzendorf Am Daßlitzer Kreuz, 50.683399, 12.129596
+Compleo DE-Leipzig BMW-Allee, 51.404114285555, 12.448011142889
+Compleo DE-Leipzig Willy-Brandt-Platz, 51.345222, 12.384168
+Compleo DE-Lemgo Parkplatz, 52.0254, 8.9076
+Compleo DE-Lemgo Parkplatz Neue, 52.0297, 8.902
+Compleo DE-Leutkirch Wangener Straße, 47.822561, 10.007333
+Compleo DE-Limbach-Oberfrohna , 50.846949958297, 12.788067033883
+Compleo DE-Limbach-Oberfrohna Helenenstraße, 50.858469, 12.758069
+Compleo DE-Limbach-Oberfrohna Kreuzeiche 8, 50.868012, 12.773944
+Compleo DE-Lübben Lindenstraße, 51.939174, 13.893805
+Compleo DE-Lüneburg Reichenbachstraße, 53.252825199451, 10.410385003433
+Compleo DE-Lüneburg Sankt-Ursula-Weg, 53.243815, 10.405607
+Compleo DE-Markkleeberg Dietrich-Bonhoeffer-Platz, 51.282954968502, 12.369724062984
+Compleo DE-Markranstädt Markt 4, 51.302059, 12.220808
+Compleo DE-Marktredwitz Wölsauer Str., 50.00412, 12.096919
+Compleo DE-Massen Turmstr., 51.634799, 13.725131
+Compleo DE-Melle Maschweg, 52.193087, 8.35808
+Compleo DE-Melle Zur Femlinde, 52.213052, 8.273416
+Compleo DE-Meuselwitz Zeitzer Str. 45, 51.047061, 12.293332
+Compleo DE-Mittweida Schillerstr., 50.985574, 12.972478
+Compleo DE-Moers , 51.451477, 6.638329
+Compleo DE-München Anton-Ditt-Bogen, 48.191788, 11.577537
+Compleo DE-München Bremer Straße, 48.189303720191, 11.570349702385
+Compleo DE-München Hanauer Straße, 48.178852, 11.530204
+Compleo DE-München Petuelring, 48.177162, 11.560011
+Compleo DE-Münster Weseler Str., 51.929826, 7.59314
+Compleo DE-Neunkirchen Margarethe-Bacher-Straße, 49.34568, 7.16795
+Compleo DE-Neusäß , 48.39446, 10.8318
+Compleo DE-Niederdorf Chemnitzer Str. 69, 50.722151, 12.784234
+Compleo DE-Oberhausen Konrad-Adenauer-Allee, 51.493189, 6.861308
+Compleo DE-Oberlichtenau Auerswalder Str., 50.905717, 12.962402
+Compleo DE-Oberschleißheim Mittenheimer Straße, 48.263154, 11.558526
+Compleo DE-Oppenheim Am, 49.846107, 8.361539
+Compleo DE-Papenburg Hauptkanal links, 53.07757, 7.39988
+Compleo DE-Peiting , 47.795510005005, 10.923899998718
+Compleo DE-Penzberg Fraunhoferstr., 47.74795, 11.38513
+Compleo DE-Plauen Pausaer Str., 50.52069, 12.114365
+Compleo DE-Radevormwald Heisenbergstraße, 51.203087943359, 7.3785364228516
+Compleo DE-Ratingen , 51.294764, 6.850773
+Compleo DE-Regensburg , 48.978594052734, 12.169961001953
+Compleo DE-Regensburg Leibnizstraße, 48.998740344393, 12.167571993534
+Compleo DE-Reichenbach Alte Ziegelei, 50.63979, 12.32899
+Compleo DE-Rheinberg Xantener Straße, 51.564787454606, 6.577478947133
+Compleo DE-Saalfeld Am Cröstener Weg, 50.655387, 11.343779
+Compleo DE-Salzgitter , 52.088093, 10.379195
+Compleo DE-Salzgitter Liebenhaller, 52.046213, 10.37178
+Compleo DE-Schöneck Hohe Reuth 10, 50.38891, 12.34966
+Compleo DE-Schrobenhausen Bahnhofstraße, 48.5647, 11.25911
+Compleo DE-Schrobenhausen Bürgermeister-Stocker-Ring, 48.55904, 11.26615
+Compleo DE-Schwerte Hörder Straße, 51.464258, 7.558028
+Compleo DE-Schwerte Wittekindstraße                     , 51.444067, 7.572438
+Compleo DE-Seeland OT Hoym Ascherslebener Str., 51.784924, 11.327695
+Compleo DE-Siegburg Luisenstraße, 50.80902, 7.192992
+Compleo DE-Speyer Alte, 49.324623, 8.446927
+Compleo DE-Speyer Bahnhofstraße, 49.319518, 8.430799
+Compleo DE-Speyer Berliner, 49.326918821119, 8.4175407302679
+Compleo DE-Speyer Fliederweg, 49.346984, 8.426018
+Compleo DE-Speyer Schifferstadter Straße, 49.341886, 8.4289528374161
+Compleo DE-Stadtbergen Benzstraße, 48.37908, 10.84784
+Compleo DE-Stuttgart-Zuffenhausen Schwieberdinger Str. 1 Bau 70, 48.837913, 9.153251
+Compleo DE-Suhl Auenstr., 50.6084641875, 10.6798931875
+Compleo DE-Tappenbeck Krümke, 52.477904075495, 10.741047948141
+Compleo DE-Tarmstedt Bremer Landstraße, 53.222489, 9.076089
+Compleo DE-Trittau Zum, 53.610193, 10.409619
+Compleo DE-Türkheim Augsburger Straße, 48.0699, 10.64556
+Compleo DE-Unkel Bundesstraße, 50.6024, 7.22194
+Compleo DE-Versmold Gartenstrasse, 52.040281964844, 8.1533256953125
+Compleo DE-Vöhringen , 48.27625, 10.07704
+Compleo DE-Wackersdorf Oskar-Von-Miller-Straße, 49.318634668184, 12.231856662922
+Compleo DE-Warburg Hüffertstraße, 51.488403, 9.139116
+Compleo DE-Weißenfels Drei Wege, 51.198023670334, 11.998328923103
+Compleo DE-Wertingen , 48.563, 10.682941230804
+Compleo DE-Wertingen Augsburger Straße, 48.55863, 10.68955
+Compleo DE-Winterberg Remmeswiese, 51.200872, 8.525441
+Compleo DE-Wipperfürth Gaulstr., 51.113593, 7.406067
+Compleo DE-Wolfenbüttel Bahnhof, 52.15985, 10.532172
+Compleo DE-Wolfenbüttel Robert-Everlien-Platz, 52.158728267015, 10.539086819482
+Compleo DE-Wolfsburg , 52.42341, 10.792297
+Compleo DE-Wolfsburg Poststrasse, 52.426676, 10.783312
+Compleo DE-Wolfsburg Rathausstraße, 52.419784297101, 10.787314847937
+Compleo DE-Wolfsburg  Willy-Brandt-Platz, 52.428981375372, 10.786001656901
+Compleo DE-Wolkenstein Hoflindenstraße, 50.674456, 13.123987
+Compleo DE-Wülfrath Am Diek, 51.280363, 7.033733
+Compleo DE-Zschopau Chemnitzer Str., 50.750228, 13.068602
+Compleo DE-Zwenkau Hafenstraße, 51.23378, 12.334526
+Compleo DE-Zwickau Uhdestraße, 50.70933, 12.50408
+Compleo DE-Zwingenberg Gießer Weg, 49.72307, 8.60184
+
 da-emobil AT-Guntramsdorf, 48.033848,16.337711,20
 da-emobil AT-Pettau, 47.284483,11.164263,20
 da-emobil AT-St. Pölten, 48.177086,15.553222

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -1858,6 +1858,226 @@ be.energised DE-Hallbergmoos Lilienthalstraße, 48.331014,11.73383
 be.energised DE-Kassel Porsche, 51.304914,9.528714
 be.energised DE-Unterschleißheim Audi Kölbl, 48.28313,11.567575
 
+BP DE-Allershausen Schroßlacher Straße, 48.428106, 11.585223
+BP DE-Altdorf bei Nürnberg Nürnberger Straße, 49.383969, 11.34805
+BP DE-Arnstadt Lindenplatz, 50.860322, 10.96045
+BP DE-Auerswalde An der, 50.893449, 12.946001
+BP DE-Augsburg Aindlinger Straße, 48.392692, 10.933418
+BP DE-Backnang Manfred-von-Ardenne-Allee 2, 48.959211, 9.423126
+BP DE-Bad Berka Weimarische Straße, 50.904707, 11.27835
+BP DE-Bad Tölz Sachsenkamer Straße, 47.760071, 11.57375
+BP DE-Bark Bockhorner Landstraße, 53.918437, 10.128499
+BP DE-Baunatal Langenbergstraße, 51.256352, 9.413303
+BP DE-Beckum Neubeckumer Straße, 51.765792, 8.042426
+BP DE-Bergisch Gladbach Dellbrücker Straße, 50.988158, 7.0877
+BP DE-Bergisch Gladbach Kölner Straße, 50.961577, 7.147529
+BP DE-Bergkamen Hellweg, 51.651404, 7.66276
+BP DE-Berlin Berliner Straße, 52.5847, 13.2879
+BP DE-Berlin Gartenfelder Straße, 52.5437, 13.2431
+BP DE-Berlin Heerstraße, 52.5168, 13.17757
+BP DE-Berlin Holzmarktstraße, 52.513834691864, 13.422426230621
+BP DE-Berlin Schnellerstraße, 52.460058, 13.503729
+BP DE-Berlin Seestraße, 52.546415, 13.345433
+BP DE-Bernburg (Saale) Hallesche Landstraße, 51.778699, 11.747512
+BP DE-Beselich , 50.469115876908, 8.1372393692209
+BP DE-Bielefeld Paderborner Straße, 51.932083, 8.60688
+BP DE-Bingen am Rhein Hitchinstraße, 49.948302, 7.903622
+BP DE-Bitburg Saarstraße, 49.955869, 6.524894
+BP DE-Blankenfelde-Mahlow Am Lückefeld, 52.358067, 13.432297
+BP DE-Blumberg Nordwerk, 47.845935, 8.55537
+BP DE-Bochum Herner Straße, 51.501771, 7.212764
+BP DE-Bochum Königsallee, 51.461087, 7.220522
+BP DE-Bochum Lütgendortmunder Hellweg, 51.494238, 7.338955
+BP DE-Bochum Wittener Straße, 51.477539999893, 7.2277610001011
+BP DE-Bockenem Oppelner Straße, 52.001907, 10.135185
+BP DE-Bremen Stapelfeldtstraße, 53.111102, 8.753153
+BP DE-Brüggen Klosterstraße 1, 51.237843, 6.189155
+BP DE-Coburg Ernst-Faber-Straße, 50.24811, 10.965753
+BP DE-Darmstadt Heinrichstraße, 49.86768, 8.682129
+BP DE-Dessau-Roßlau Junkersstraße, 51.82599, 12.214922
+BP DE-Dietzenbach Elisabeth-Selbert-Straße, 50.013672, 8.794647
+BP DE-Dietzhölztal Storchweg, 50.834682, 8.325993
+BP DE-Dortmund Flughafenstraße, 51.549116, 7.538578
+BP DE-Dortmund Rheinlanddamm, 51.499476, 7.471573
+BP DE-Dortmund Westfalendamm, 51.504057, 7.498477
+BP DE-Dresden Am, 51.094514777686, 13.735862112393
+BP DE-Dresden Bergstraße, 51.020081, 13.73055
+BP DE-Dresden Hamburger Straße, 51.062691, 13.680067
+BP DE-Dresden Werftstraße, 51.069016, 13.690236
+BP DE-Duderstadt Gewerbepark Euzenberg, 51.510505, 10.240672
+BP DE-Duisburg Friedrich-Ebert-Straße, 51.405114, 6.712324
+BP DE-Düren Nordstraße, 50.832423, 6.458671
+BP DE-Düsseldorf Lütticher Straße, 51.239845, 6.744111
+BP DE-Düsseldorf Münchener Straße, 51.169148, 6.823486
+BP DE-Düsseldorf Südring, 51.200938, 6.762804
+BP DE-Eislingen/Fils Stuttgarter Straße, 48.696351, 9.690648
+BP DE-Elmshorn Werner-von-Siemens-Str., 53.745358, 9.7048
+BP DE-Eltville am Rhein Schlangenbader Straße, 50.055968, 8.11955
+BP DE-Emmerich am Rhein Marie-Curie-Straße, 51.84198, 6.275056
+BP DE-Enkenbach-Alsenborn Hochspeyerer Straße, 49.483675, 7.900407
+BP DE-Erding Sigwolfstraße, 48.314821, 11.89309
+BP DE-Eschweiler Rue de Wattrelos, 50.82532, 6.247152
+BP DE-Espelkamp Isenstedter Straße, 52.3741, 8.634504
+BP DE-Essen Holsterhauser Straße, 51.446449, 7.000764
+BP DE-Essen Karnaper Straße, 51.517619, 7.007992
+BP DE-Essen Rellinghauser Straße, 51.434878, 7.033927
+BP DE-Frankfurt am Main Carl-Benz-Straße, 50.120998, 8.749289
+BP DE-Frankfurt am Main Hanauer Landstraße, 50.112761, 8.700001
+BP DE-Freiburg im Breisgau Engesserstraße, 48.018660224111, 7.842211891808
+BP DE-Freisen Baumholderstraße, 49.554605, 7.256143
+BP DE-Fritzlar Gießener Straße, 51.120540523867, 9.2785427263134
+BP DE-Fürstenwalde/Spree Friedenstraße, 52.335629, 14.073284
+BP DE-Garching bei München Schleißheimer Straße, 48.250519428969, 11.606805188839
+BP DE-Gau-Algesheim Rheinstraße, 49.964622, 8.017696
+BP DE-Geesthacht Geesthachter Straße, 53.439831, 10.365795
+BP DE-Geislingen an der Steige Schillerstraße 34, 48.609518, 9.842633
+BP DE-Gelsenkirchen Gewerkenstraße, 51.519659, 7.082324
+BP DE-Gladbeck Hermannstraße, 51.574721, 6.981985
+BP DE-Glasin A20, 53.909214, 11.758253
+BP DE-Greifswald Koitenhäger Landstraße, 54.081248, 13.428943
+BP DE-Gremsdorf Gewerbepark, 49.698492, 10.854734
+BP DE-Grimma Hengstbergstraße, 51.256011, 12.72606
+BP DE-Großhansdorf Sieker Landstraße, 53.644633, 10.278368
+BP DE-Hagen Hagener Straße, 51.386465, 7.477907
+BP DE-Halle (Saale) Dessauer Platz, 51.497638, 11.982227
+BP DE-Halle (Saale) Eislebener Chaussee, 51.47177, 11.905076
+BP DE-Hamburg Bremer Straße, 53.438596, 9.936119
+BP DE-Hamburg Großmannstraße, 53.536485, 10.064796
+BP DE-Hamburg Langenhorner Chaussee, 53.638696, 10.013557
+BP DE-Hamburg Nettelnburger Landweg, 53.486731, 10.184006
+BP DE-Hamburg Osdorfer Landstraße, 53.571399, 9.870053
+BP DE-Hamburg Otto-Brenner-Straße, 53.489877, 10.018841
+BP DE-Hamburg Poppenbütteler Weg, 53.649829, 10.064677
+BP DE-Hameln Fischbecker Landstraße, 52.121274, 9.334876
+BP DE-Hamm Hammer Straße, 51.690016, 7.775152
+BP DE-Hamm Werler Straße, 51.616665, 7.848467
+BP DE-Hanau Brüder-Grimm-Straße, 50.1278, 8.91703
+BP DE-Hanau Maintaler Straße, 50.14754, 8.90096
+BP DE-Hannover , 52.329484, 9.812107
+BP DE-Hannover Göttinger Chaussee, 52.345632, 9.717012
+BP DE-Hannover Hans-Böckler-Allee, 52.371506, 9.77335
+BP DE-Hannover Vahrenwalder Straße, 52.40515, 9.735858
+BP DE-Hemmingen Freiherr-von-Varnbüler-Straße, 48.864851, 9.039397
+BP DE-Henstedt-Ulzburg Rudolf-Diesel-Straße, 53.803703, 9.938815
+BP DE-Herford Röntgenstraße, 52.061311, 8.644352
+BP DE-Hessisch Lichtenau Leipziger Straße, 51.198117, 9.74601
+BP DE-Heusweiler Trierer Straße, 49.341224, 6.933607
+BP DE-Hildesheim Mastbergstraße, 52.170471, 9.93408
+BP DE-Himmelkron Hofer Straße, 50.05456, 11.622459
+BP DE-Hofgeismar Grebensteiner Straße, 51.481432, 9.38993
+BP DE-Holzkirchen Miesbacher Straße, 47.875762, 11.710729
+BP DE-Horb am Neckar Bildechinger Steige, 48.45527, 8.699629
+BP DE-Höxter Albaxer Straße, 51.786734, 9.387784
+BP DE-Ingelheim am Rhein Konrad-Adenauer-Straße, 49.979082, 8.054044
+BP DE-Ingersleben Zuckerfabrik, 52.209345, 11.13259
+BP DE-Ingolstadt Schollstraße, 48.775199, 11.459173
+BP DE-Iserlohn Baarstraße, 51.400379, 7.697761
+BP DE-Isselburg Dekkers Waide, 51.817815, 6.443986
+BP DE-Jülich Neusser Straße, 50.928056, 6.365766
+BP DE-Kaltenkirchen Kieler Straße, 53.840768, 9.947625
+BP DE-Kammerstein An der Autobahn, 49.311461, 11.002057
+BP DE-Kassel Druseltalstraße, 51.307116, 9.447287
+BP DE-Kassel Leipziger Straße, 51.301048, 9.533371
+BP DE-Kerken Umgehungsstraße, 51.442739, 6.414219
+BP DE-Kerpen Erftstraße, 50.911672, 6.683405
+BP DE-Kiel Schwedendamm, 54.307323, 10.136597
+BP DE-Kirchhain Sonnenallee, 50.82377, 8.944448
+BP DE-Kirchheimbolanden Bischheimer Straße, 49.668378, 8.019714
+BP DE-Knüllwald Hauptstraße, 51.00671, 9.472923
+BP DE-Kolbermoor Aiblinger Au, 47.851146, 12.017452
+BP DE-Köln Am, 50.892176, 6.966475
+BP DE-Köln Bergisch Gladbacher Straße, 50.967782, 7.034807
+BP DE-Köln Kölner Straße, 50.903592, 7.020729
+BP DE-Köln Oskar-Schindler-Straße, 51.032809, 6.919276
+BP DE-Köln Riehler Straße, 50.952498, 6.961947
+BP DE-Köln Widdersdorfer Straße, 50.946984, 6.880376
+BP DE-Königs Wusterhausen Robert-Guthmann-Straße, 52.314431698729, 13.662795
+BP DE-Konstanz Opelstraße, 47.67595, 9.152839
+BP DE-Kressbronn am Bodensee Linderhof, 47.60761, 9.586792
+BP DE-Kreuztal Hagener Straße, 50.961375, 7.988984
+BP DE-Lahr/Schwarzwald Freiburger Straße, 48.340198, 7.842522
+BP DE-Langenfeld (Rheinland) Hardt, 51.1195, 6.973796
+BP DE-Langenhagen Vahrenwalder Straße, 52.423851, 9.732302
+BP DE-Lehre In den Lohbalken, 52.310834, 10.634943
+BP DE-Leipzig An der, 51.312921, 12.404032
+BP DE-Leipzig Maximilianallee, 51.385619, 12.389905
+BP DE-Leipzig Max-Liebermann-Straße, 51.376073, 12.37766
+BP DE-Leverkusen Solinger Straße, 51.056073, 6.953897
+BP DE-Luckau Autobahn, 51.911746, 13.796516
+BP DE-Luckau Rüblingsheide BAB, 51.888672, 13.837394
+BP DE-Lüdenscheid Werdohler Landstraße, 51.22859, 7.65142
+BP DE-Magdeburg Jerichower Straße, 52.131938, 11.665659
+BP DE-Magdeburg Salbker Chaussee, 52.082785, 11.602965
+BP DE-Mannheim Brandenburger Straße, 49.511984, 8.529924
+BP DE-Marburg Am Krekel, 50.794059, 8.760681
+BP DE-Mayen Kelberger Straße, 50.325661, 7.213521
+BP DE-Meißen Hochuferstraße, 51.169111, 13.471323
+BP DE-Mellingen Aralallee, 50.93452, 11.389496
+BP DE-Menden (Sauerland) Fröndenberger Straße, 51.468173, 7.76905
+BP DE-Minden Ringstraße, 52.299628, 8.910349
+BP DE-Mitterteich Gottlieb-Daimler-Straße, 49.937048, 12.227611
+BP DE-Moers Römerstraße, 51.443927, 6.661042
+BP DE-Moosburg an der Isar Landshuter Straße, 48.463953, 11.939814
+BP DE-Mörfelden-Walldorf Industriestraße, 49.979273, 8.581791
+BP DE-Mühlhausen/Thüringen Gebr.-Franke-Straße, 51.198597, 10.480126
+BP DE-Mühltal Odenwaldstraße, 49.830129, 8.706035
+BP DE-Müllheim im Markgräflerland Werderstraße, 47.808872, 7.639675
+BP DE-Münster Steinfurter Straße, 51.967434, 7.613318
+BP DE-Neckarsulm Neuenstädter Straße, 49.198907, 9.232369
+BP DE-Nettetal Kempener Straße, 51.310784, 6.290851
+BP DE-Neudrossenfeld An der Autobahn, 50.037146233629, 11.490630369873
+BP DE-Neuhausen auf den Fildern Plieninger Straße, 48.691219, 9.2663
+BP DE-Neumarkt in der Oberpfalz Oberes Moos, 49.259527, 11.458672
+BP DE-Neuss Bergheimer Straße, 51.181253, 6.688381
+BP DE-Niederdorf Neue Schichtstraße, 50.724782, 12.778835
+BP DE-Niederwinkling Industriestraße, 48.893933, 12.800573
+BP DE-Norden Bahnhofstraße, 53.58828, 7.21853
+BP DE-Nürnberg Erlanger Straße, 49.474162, 11.064742
+BP DE-Oberhausen Teutoburger Straße, 51.517044, 6.857017
+BP DE-Obernburg am Main Miltenberger Straße, 49.83721, 9.14403
+BP DE-Obertshausen Im Birkengrund, 50.062794, 8.830192
+BP DE-Osnabrück Alte Poststraße, 52.276945, 8.055264
+BP DE-Osnabrück Pagenstecherstraße, 52.289396, 8.028853
+BP DE-Oyten Oyterdamm, 53.057411, 8.967182
+BP DE-Paderborn Dubelohstraße, 51.745332, 8.731176
+BP DE-Radolfzell am Bodensee Eisenbahnstraße, 47.7417, 8.955
+BP DE-Raubling Rosenheimer Straße, 47.804791, 12.119877
+BP DE-Regensburg Kirchmeierstraße, 49.011056, 12.070869
+BP DE-Rheinböllen Bahnhofstraße, 49.996285, 7.683968
+BP DE-Rüsselsheim am Main Mainzer Straße, 49.993412, 8.386241
+BP DE-Saarlouis Metzer Straße, 49.305459, 6.74008
+BP DE-Sankt Ingbert Saarbrücker Straße, 49.275611, 7.110575
+BP DE-Schackendorf BAB, 53.960054, 10.260901
+BP DE-Schlüsselfeld Attelsdorf, 49.745937, 10.634417
+BP DE-Schönfeld Königsbrücker Straße, 51.295416, 13.730064
+BP DE-Schuby Westring, 54.518967, 9.464545
+BP DE-Schweinfurt Straßburgstraße, 50.021178, 10.215869
+BP DE-Schweinfurt Willi-Kaidel-Straße, 50.054058, 10.194942
+BP DE-Sittensen Stader Straße, 53.288552, 9.50834
+BP DE-Soest Overweg, 51.55337, 8.158545
+BP DE-Soltau Gottlieb-Daimler-Straße, 52.996895, 9.921231
+BP DE-Sprockhövel Wittener Straße, 51.340392, 7.289735
+BP DE-Stendal Arneburger Straße, 52.616963, 11.868436
+BP DE-Straubing Aiterhofener Straße, 48.872765, 12.630852
+BP DE-Sulz am Neckar Stuttgarter Straße, 48.36714, 8.636584
+BP DE-Uplengen Rudolf-Diesel-Straße, 53.262665, 7.755892
+BP DE-Vechta Osloer Straße, 52.731188, 8.265227
+BP DE-Wang Gewerbepark Spörer Au, 48.482866, 12.000469
+BP DE-Warburg Paderborner Tor 180/B, 51.494593, 9.126022
+BP DE-Weeze Industriestraße, 51.620177, 6.209968
+BP DE-Weingarten Waldseer Straße, 47.817642, 9.64217
+BP DE-Werneuchen Freienwalder Straße, 52.6363, 13.7449
+BP DE-Wesel Weseler Straße, 51.638324, 6.587322
+BP DE-Wetter (Hessen) An der Bleiche, 50.904398, 8.721228
+BP DE-Wiesbaden Berliner Straße, 50.053831212197, 8.3004190969009
+BP DE-Wietmarschen Benzstraße, 52.482153, 7.217292
+BP DE-Wolfsburg , 52.427795, 10.775238
+BP DE-Wollin Im Gewerbegebiet, 52.288976, 12.463941
+BP DE-Wörth am Main Landstraße, 49.79783, 9.15649
+BP DE-Wunstorf Kolenfelder Straße, 52.416923, 9.448295
+BP DE-Wuppertal Nevigeser Straße, 51.268683, 7.126744
+BP DE-Zwickau Leipziger Straße, 50.742861, 12.488611
+
 chargeIT DE-Coburg Arena, 50.287087, 10.980806
 chargeIT DE-Coburg Audi Gelder & Sorg, 50.271384,10.968691
 chargeIT DE-Kaufbeuren, 47.88613,10.638898, 10

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -6135,8 +6135,14 @@ Kaufland CZ-Praha (Hrdlořezy), 50.092464, 14.499563, 30
 Kaufland CZ-Praha (Kolbenova), 50.109281, 14.544551, 30
 Kaufland DE-Aachen, 50.769387, 6.058244
 Kaufland DE-Aalen,48.8338761,10.0954643
+Kaufland DE-Ahaus Andreasstraße 3-5, 52.066251, 6.964758
+Kaufland DE-Ahlen Kleiwellenfeld 16, 51.739317, 7.877637
 Kaufland DE-Ansbach, 49.305557,10.588955
+Kaufland DE-Apolda Bernhard-Prager-Gasse 1-7, 51.025269, 11.513087
+Kaufland DE-Arnsberg Westring 10, 51.429804, 8.011223
+Kaufland DE-Arnstadt Alfred-Ley-Straße 12, 50.855904, 10.955762
 Kaufland DE-Aschaffenburg, 49.968144, 9.165434
+Kaufland DE-Augsburg Meraner Straße 6, 48.380870742187, 10.932866
 Kaufland DE-Backnang, 48.962571,9.43141
 Kaufland DE-Bad Dürrheim,48.0304896,8.5257497
 Kaufland DE-Bad Friedrichshall, 49.230394, 9.21173
@@ -6144,98 +6150,253 @@ Kaufland DE-Bad Nauheim,50.3798621,8.7320255
 Kaufland DE-Bad Neustadt,50.3257512,10.2229594
 Kaufland DE-Bad Rappenau, 49.2362, 9.096765, 60
 Kaufland DE-Bad Saulgau,48.0075619,9.5115572
+Kaufland DE-Bad Tölz Lenggrieser Straße 47, 47.753807, 11.56343
 Kaufland DE-Baden-Baden, 48.782543, 8.20803, 20
+Kaufland DE-Bayreuth Weiherstraße 27, 49.96459, 11.599049
 Kaufland DE-Bergheim, 50.952842, 6.641612
+Kaufland DE-Berlin Buckower Chaussee 100, 52.410484, 13.381804
+Kaufland DE-Berlin Eichhorster Weg 96, 52.603595, 13.335526
+Kaufland DE-Berlin Goerzallee 195, 52.417221, 13.286431
 Kaufland DE-Berlin Grünhofer Weg, 52.533887, 13.188849
 Kaufland DE-Berlin Gutschmidtstraße, 52.436452, 13.447838
 Kaufland DE-Berlin Markthalle Alexanderplatz, 52.522205,13.407149
+Kaufland DE-Berlin Märkische Allee 166, 52.533523, 13.538283
 Kaufland DE-Berlin Ollenhauerstraße, 52.567428, 13.328217
+Kaufland DE-Berlin Pichelswerderstraße 6, 52.5299, 13.213127
 Kaufland DE-Berlin Prenzlauer Berg, 52.533964, 13.457147
 Kaufland DE-Berlin Residenzstraße, 52.558806, 13.372718
 Kaufland DE-Berlin Rummelsburgerstr., 52.499526,13.496195
 Kaufland DE-Berlin Tempelhof,52.468372,13.377201,20
+Kaufland DE-Berlin Wilhelmstraße 21-25, 52.521375, 13.186769
 Kaufland DE-Bietigheim-Bissingen,48.9609387,9.1306524
+Kaufland DE-Bitburg Kölner Straße 11, 49.977525, 6.526619
+Kaufland DE-Bocholt Welfenstraße 21, 51.831327, 6.610441
 Kaufland DE-Borna,51.1096668,12.4883806
+Kaufland DE-Bottrop Berliner Platz 8, 51.522538, 6.929221
+Kaufland DE-Braunschweig Hamburger Straße 250, 52.282839, 10.520643
+Kaufland DE-Bremen Sebaldsbrücker Heerstraße 155, 53.06028, 8.89253
 Kaufland DE-Bretten,49.0404049,8.6890822
+Kaufland DE-Burgstädt Mittweidaer Straße 1, 50.919007, 12.815512
+Kaufland DE-Burgthann Espenpark 30, 49.316819, 11.34043
+Kaufland DE-Bühl Bühlertalstraße 71, 48.695776, 8.147005
+Kaufland DE-Bühl Güterstraße 10, 48.699103, 8.132357
 Kaufland DE-Chemnitz,50.7837844,12.8955127
+Kaufland DE-Coswig Salzstraße 16a, 51.133246, 13.585782
 Kaufland DE-Crailsheim,49.140163,10.034126,10
+Kaufland DE-Dachau Danziger Straße 1, 48.258571, 11.46666
+Kaufland DE-Dillingen an der Donau Johannes-Scheiffele-Straße 3-7, 48.578666, 10.478157
+Kaufland DE-Dillingen/Saar Daimlerstraße 4, 49.36785, 6.71343
+Kaufland DE-Dippoldiswalde Industriering 2, 50.89745, 13.694165
+Kaufland DE-Donauwörth Neurieder Weg 33, 48.719803, 10.761971
 Kaufland DE-Dortmund Bornstr., 51.528575, 7.470953
 Kaufland DE-Dortmund Luisenglück, 51.477365, 7.432908
+Kaufland DE-Dossenheim Gewerbestraße 19, 49.454209, 8.664673
+Kaufland DE-Dresden Kohlenstraße 18, 51.019624, 13.722317
 Kaufland DE-Dresden Borsbergstraße,51.0444467,13.7811108
+Kaufland DE-Duisburg Duisburger Straße 303, 51.497109, 6.765615
+Kaufland DE-Dörfles-Esbach Coburger Straße 2, 50.279546, 10.989413
+Kaufland DE-Düsseldorf Professor-Neyses-Platz 6, 51.250483, 6.790978
 Kaufland DE-Eppingen, 49.137519, 8.915462
 Kaufland DE-Erding, 48.305332, 11.881886
+Kaufland DE-Erftstadt Gustav-Heinemann-Straße 2, 50.802038, 6.813292
 Kaufland DE-Erfurt, 50.955663, 11.069766
 Kaufland DE-Erlangen, 49.593323, 11.026181
 Kaufland DE-Essen, 51.473618, 6.999701
 Kaufland DE-Essen-Borbeck, 51.473133, 6.952699
 Kaufland DE-Esslingen am Neckar,48.724231,9.352168
 Kaufland DE-Fellbach, 48.813484, 9.266494
+Kaufland DE-Feuchtwangen Dinkelsbühler Straße 34, 49.161866, 10.327037
 Kaufland DE-Frankfurt, 50.132218, 8.749362
 Kaufland DE-Fredersdorf-Vogelsdorf, 52.497356, 13.744505
+Kaufland DE-Freilassing Verdistraße 15, 47.843966, 12.969126
+Kaufland DE-Friedberg Marquardtstraße 1, 48.348241, 10.996155
+Kaufland DE-Friedrichshafen Stockerholzstraße 12, 47.663314, 9.433604
+Kaufland DE-Fürstenwalde/Spree Juri-Gagarin-Straße 32, 52.377976, 14.079854
+Kaufland DE-Geisenfeld Bajuwarenstraße 4, 48.740601, 11.633491
+Kaufland DE-Geislingen an der Steige Neuwiesenstraße 25, 48.610356, 9.806548
+Kaufland DE-Gera Schleizer Straße 36-39, 50.847564, 12.066425
+Kaufland DE-Gerlingen Weilimdorfer Straße 93, 48.807665, 9.075957
+Kaufland DE-Germersheim Mainzer Straße 6, 49.229197, 8.368138
 Kaufland DE-Giengen an der Brenz, 48.621067, 10.250653
 Kaufland DE-Gröbenzell, 48.186468, 11.38609
+Kaufland DE-Grünstadt Kirchheimer Straße 39, 49.56122, 8.168912
 Kaufland DE-Göppingen, 48.704563, 9.647031
+Kaufland DE-Göttingen Kurze-Geismar-Straße 26-30, 51.531091, 9.938112
+Kaufland DE-Halberstadt Braunschweiger Straße 83-88, 51.898774, 11.03972
+Kaufland DE-Hamm Münsterstraße 183, 51.702144, 7.798651
+Kaufland DE-Hannover Bornumer Straße 141, 52.352121, 9.694804
 Kaufland DE-Hattingen, 51.397722, 7.182943
+Kaufland DE-Hauzenberg Florianstraße 1, 48.657318, 13.630441
+Kaufland DE-Hechingen Kaullastraße 1, 48.374862, 8.961404
 Kaufland DE-Hechingen, 48.354134,8.974779
+Kaufland DE-Heidelberg Eppelheimer Straße 78, 49.403418, 8.646239
+Kaufland DE-Heidenheim an der Brenz Aalener Straße 20, 48.713789, 10.161584
+Kaufland DE-Heilbronn Neckargartacher Straße 111, 49.151304, 9.196075
+Kaufland DE-Heilbronn Olgastraße 57, 49.137231, 9.208609
 Kaufland DE-Heilbronn, 49.12452, 9.223451
+Kaufland DE-Herne Hauptstraße 211, 51.527676, 7.159594
+Kaufland DE-Hohen Neuendorf Schönfließerstraße 66, 52.671069, 13.280925
+Kaufland DE-Hoyerswerda Straße E 9, 51.431243, 14.286416
 Kaufland DE-Hussenhofen, 48.803978, 9.839545
+Kaufland DE-Höchstadt Rothenburger Straße 19, 49.706632, 10.799295
 Kaufland DE-Ilmenau, 50.683092,10.919349
+Kaufland DE-Ilsfeld Robert-Mayer-Straße 19, 49.057927, 9.261101
+Kaufland DE-Ingolstadt Richard-Wagner-Straße 40, 48.774508, 11.398906
+Kaufland DE-Jena Naumburger Straße 57 a, 50.951697, 11.610572
+Kaufland DE-Kamenz Willy-Muhle-Straße 25, 51.269044, 14.112453
+Kaufland DE-Kassel Franzgraben 40-42, 51.321077, 9.518043
 Kaufland DE-Kaufbeuren, 47.884276, 10.636879
+Kaufland DE-Kirchentellinsfurt Wannweiler Straße 77, 48.524673, 9.145034
+Kaufland DE-Kolkwitz Berliner Straße 114, 51.752058, 14.261367
+Kaufland DE-Konstanz Carl-Benz-Straße 22, 47.677178, 9.148122
+Kaufland DE-Konz Saar-Mosel-Platz 2, 49.698988, 6.574571
+Kaufland DE-Kreuztal Marburger Straße 41, 50.961812, 7.99448
+Kaufland DE-Köln Boltensternstraße 104, 50.972533, 6.976868
+Kaufland DE-Köln Frankfurter Straße 87A, 50.958903, 7.015017
 Kaufland DE-Köln Ostmerheimer Straße,50.9417649,7.051004
+Kaufland DE-Königs Wusterhausen Luckenwalder Str.7, 52.294791, 13.620696
+Kaufland DE-Königsbrunn Germanenstraße 16, 48.286884, 10.890218
+Kaufland DE-Künzelsau Bergstraße 9, 49.277427, 9.683906
+Kaufland DE-Lahr/Schwarzwald Offenburger Straße 11, 48.344966, 7.841325
+Kaufland DE-Leipzig Anton-Zickmantel-Straße 42, 51.303335, 12.3223
+Kaufland DE-Leipzig Torgauer Straße 279, 51.367122, 12.457646
 Kaufland DE-Leipzig, 51.33711, 12.336445
+Kaufland DE-Leipzig-Gohlis-Süd Georg-Schumann-Straße 105-109, 51.362434, 12.36236
 Kaufland DE-Leipzig Dresdner Straße,51.3373523,12.4047889
 Kaufland DE-Leipzig Georg-Schumann-Straße,51.3730247,12.3289103
 Kaufland DE-Leonberg, 48.797085, 9.006616
 Kaufland DE-Lichtenfels, 50.137785, 11.074773
+Kaufland DE-Limbach-Oberfrohna Ostring 4, 50.855587, 12.784365
+Kaufland DE-Lindau (Bodensee) Heuriedweg 21, 47.554012, 9.712198
 Kaufland DE-Lohmar,50.839312,7.206288
+Kaufland DE-Lutherstadt Eisleben Hallesche Straße 77, 51.523873, 11.557884
 Kaufland DE-Lörrach,47.6259194,7.673703
+Kaufland DE-Magdeburg Halberstädter Straße 182-186, 52.107368, 11.592481
+Kaufland DE-Magdeburg Lübecker Straße 122, 52.154206, 11.638545
+Kaufland DE-Mainz Haifa-Allee 1, 49.969451, 8.2278
 Kaufland DE-Mannheim Maybachstraße,49.5035437,8.476409
 Kaufland DE-Marbach am Neckar, 48.943393, 9.266666
+Kaufland DE-Markt Schwaben Burgerfeld 8, 48.191777, 11.851564
+Kaufland DE-Marktredwitz Bayreuther Straße 15, 50.010001, 12.076132
+Kaufland DE-Marl Lipper Weg 4, 51.663485, 7.128495
+Kaufland DE-Mayen Koblenzer Straße 174A, 50.325815, 7.248867
 Kaufland DE-Meerane, 50.835734, 12.449844
+Kaufland DE-Meiningen Werrastraße 14, 50.557282, 10.413429
+Kaufland DE-Merseburg Querfurter Straße 16, 51.371386, 11.97673
 Kaufland DE-Metzingen,48.5410607,9.2784699
 Kaufland DE-Mitweida, 50.99454, 12.96435
+Kaufland DE-Moers Römerstraße 570, 51.454562, 6.65727
 Kaufland DE-Monheim, 51.087347, 6.889933
+Kaufland DE-Monschau Auf Beuel 19, 50.577561, 6.257177
+Kaufland DE-Mosbach Pfalzgraf-Otto-Straße 54, 49.341478, 9.126114
+Kaufland DE-Möckmühl Habichtshöfe 1, 49.297532069329, 9.3763436496523
 Kaufland DE-Mödrath, 50.880153,6.693018
 Kaufland DE-Möhringen, 48.731015,9.150352
+Kaufland DE-Mönchengladbach Reyerhütte 1, 51.192003, 6.459484
 Kaufland DE-Mönchengladbach, 51.182896, 6.411377
+Kaufland DE-Mühlhausen/Thüringen Papiermühlenweg 18, 51.224361, 10.451265
 Kaufland DE-Münchberg, 50.190847, 11.783391
+Kaufland DE-Nagold Haiterbacher Straße 82-86, 48.544061, 8.729978
+Kaufland DE-Naila Dr.-Hans-Künzel-Straße 1, 50.323575, 11.705792
 Kaufland DE-Neckarsulm,49.1723558,9.222237
+Kaufland DE-Neu-Ulm Memminger Straße 54, 48.385571, 10.004221
+Kaufland DE-Neubrandenburg Juri-Gagarin-Ring 40, 53.556419, 13.293585
+Kaufland DE-Neumarkt in der Oberpfalz Altdorfer Straße 63, 49.291227, 11.459266
+Kaufland DE-Neunkirchen Kirkeler Straße 50, 49.3291, 7.185309
+Kaufland DE-Neuss Bataverstraße 93, 51.231556, 6.686661
+Kaufland DE-Neustadt an der Aisch Robert-Bosch-Straße 2, 49.5813, 10.637254
+Kaufland DE-Neustadt an der Donau Gewerbepark 48, 48.798193, 11.76134
+Kaufland DE-Neusäß Daimlerstraße 18, 48.394243, 10.82446
+Kaufland DE-Nördlingen Raiffeisenstraße 4, 48.857513, 10.480366
+Kaufland DE-Nürnberg Dianaplatz 23-25, 49.427406, 11.066446
+Kaufland DE-Nürnberg Schwabacher Straße 99, 49.436756, 11.051168
 Kaufland DE-Oberasbach, 49.435136, 10.967694
+Kaufland DE-Offenburg Okenstrasse 74, 48.481463, 7.94686
 Kaufland DE-Offenburg, 48.470007, 7.925176
+Kaufland DE-Parchim Friedrich-Wilhelm-Raiffeisen-Ring 4, 53.418147, 11.821738
+Kaufland DE-Peißenberg Schongauer Straße 20, 47.793666, 11.061823
+Kaufland DE-Pfaffenhofen an der Ilm Max-Weinberger-Straße 9, 48.529741, 11.531414
 Kaufland DE-Pforzheim, 48.886253, 8.668658
 Kaufland DE-Pfungstadt, 49.813871,8.61979
+Kaufland DE-Pirna Struppener Straße 11A, 50.957558, 13.958268
+Kaufland DE-Pocking Passauer Straße 160, 48.41022, 13.332899
+Kaufland DE-Potsdam Zeppelinstraße 132, 52.389331, 13.030532
 Kaufland DE-Radebeul, 51.09958, 13.6543
 Kaufland DE-Ravensburg, 47.767777, 9.604267
+Kaufland DE-Rees Grüttweg 42-46, 51.767412, 6.381882
+Kaufland DE-Regensburg Hans-Hayder-Straße 2, 49.03398, 12.111104
+Kaufland DE-Rendsburg Schleswiger Chaussee, 54.319974, 9.636575
+Kaufland DE-Rheda-Wiedenbrück Bahnhofstraße 36, 51.852895355764, 8.2871946947047
 Kaufland DE-Rheinfelden,47.5752153,7.7992358
+Kaufland DE-Riegelsberg Saarbrücker Straße 262, 49.322677, 6.939136
+Kaufland DE-Ritterhude Rosenhügel 5, 53.180804, 8.708573
+Kaufland DE-Rosenheim Kufsteiner Straße 124, 47.838391, 12.120908
+Kaufland DE-Rosenheim Äußere Münchener Straße 100, 47.847333, 12.090766
+Kaufland DE-Rostock Pütterweg 1, 54.076342, 12.121373
+Kaufland DE-Roth Friedrich-Wambsganz-Straße 1, 49.249014, 11.093198
+Kaufland DE-Rottenburg am Neckar Tübinger Straße 2, 48.473405, 8.935785
 Kaufland DE-Rottweil,48.1495246,8.6403424
+Kaufland DE-Rüsselsheim am Main Alzeyer Straße 11, 49.983939, 8.401156
+Kaufland DE-Salzwedel Karl-Marx-Straße 13, 52.857506, 11.151116
 Kaufland DE-Sangerhausen, 51.470027, 11.294025
 Kaufland DE-Sankt Ingbert, 49.281439, 7.10554
 Kaufland DE-Schorndorf,48.8072115,9.5425991
+Kaufland DE-Schrobenhausen Augsburger Straße 43, 48.550926, 11.263432
 Kaufland DE-Schwaigern, 49.13824, 9.064656
+Kaufland DE-Schweinfurt Hauptbahnhofstraße 4, 50.038491, 10.218707
 Kaufland DE-Schwetzingen, 49.38544, 8.577604
 Kaufland DE-Schwäbisch-Hall, 49.105002, 9.702927
+Kaufland DE-Siegen Hagener Straße 133, 50.887773, 8.028533
+Kaufland DE-Sindelfingen Calwer Straße 4, 48.70711, 8.99733
 Kaufland DE-Sindelfingen,48.704952,9.017883,60
 Kaufland DE-Sinsheim,49.2478481,8.8810142
+Kaufland DE-Sinzig Industriestraße 10, 50.547588, 7.258573
+Kaufland DE-Spaichingen Obere Wiesen 1, 48.068576, 8.749615
+Kaufland DE-Speyer Auestraße 22, 49.333531, 8.438537
+Kaufland DE-Spremberg An der Lusatia 1, 51.557937, 14.355854
+Kaufland DE-Stade Freiburger Straße 2, 53.605005, 9.476026
 Kaufland DE-Steinheim an der Murr, 48.970356, 9.267212
 Kaufland DE-Stolberg,50.763753,6.230912
+Kaufland DE-Stollberg/Erzgeb. Auer Straße 20, 50.706937, 12.757741
 Kaufland DE-Straubing,48.8758396,12.5491142
+Kaufland DE-Strausberg Otto-Grotewohl-Ring 72, 52.573861, 13.897498
+Kaufland DE-Stuttgart Augsburger Straße 460, 48.775645, 9.257786
 Kaufland DE-Stuttgart, 48.840477, 9.229187
+Kaufland DE-Sulzbach-Rosenberg Krötenseestraße 1, 49.496567, 11.743532
 Kaufland DE-Tettnang, 47.662622, 9.5714659
+Kaufland DE-Torgau Turnierplatzweg 1, 51.548071, 12.997464
+Kaufland DE-Traunstein Theresienstraße 2, 47.87185, 12.637156
+Kaufland DE-Trier Aachener Straße 58, 49.755022, 6.624246
 Kaufland DE-Troisdorf, 50.813239, 7.1557
+Kaufland DE-Tuttlingen Stockacher Straße 146, 47.973943, 8.827381
 Kaufland DE-Tübingen, 48.514286, 9.066617
 Kaufland DE-Uhingen, 48.714102, 9.56216
+Kaufland DE-Unterschleißheim Andreas-Danzer-Weg 2, 48.285699, 11.561345
 Kaufland DE-Velbert, 51.335796, 7.049863
+Kaufland DE-Verden (Aller) Schulstraße 22, 52.952689, 9.235589
 Kaufland DE-Vilshofen an der Donau,48.607649,13.170784
+Kaufland DE-Vöhringen Industriestraße 37, 48.287917, 10.078009
 Kaufland DE-Völklingen, 49.243299,6.840921
+Kaufland DE-Waldkraiburg Teplitzer Straße 12-14, 48.206427, 12.407425
 Kaufland DE-Waldshut-Tiengen,47.6239457,8.2178741
+Kaufland DE-Weiden in der Oberpfalz Untere Bauscherstraße 25, 49.661206, 12.154987
+Kaufland DE-Weilheim in Oberbayern Kaltenmoserstraße 28, 47.843193, 11.149963
 Kaufland DE-Weimar, 50.96384, 11.311157
+Kaufland DE-Weingarten Karlstraße 21, 47.807261, 9.641764
 Kaufland DE-Weinsberg,49.1502909,9.2988399
 Kaufland DE-Weiterstadt, 49.902437, 8.608824
 Kaufland DE-Weißenburg i.Bay, 49.0271, 10.9853, 60
+Kaufland DE-Weißenfels Max-Planck-Straße 3, 51.187815, 11.981749
 Kaufland DE-Wendelstein, 49.334844, 11.114895
+Kaufland DE-Wendlingen am Neckar Wertstraße 12, 48.672707, 9.36416
+Kaufland DE-Wernigerode Am Schreiberteich 3, 51.842914, 10.781214
+Kaufland DE-Wertheim Bismarckstraße 26, 49.767119, 9.509252
 Kaufland DE-Witten, 51.439311, 7.329356
 Kaufland DE-Wuppertal, 51.233376,7.074497
+Kaufland DE-Würzburg Industriestraße 3, 49.812884, 9.977699
 Kaufland DE-Zimmern ob Rottweil,48.170971,8.5764873
+Kaufland DE-Zwickau Äußere Dresdner Straße 25, 50.719371, 12.521533
+Kaufland DE-Öhringen Haagweg 11, 49.202118, 9.500508
 
 Kaufland RO-Bacau,46.538510,26.912280
 Kaufland RO-Balș,44.343806,24.124408

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -8586,6 +8586,61 @@ TEAG DE-Gera Globus, 50.8874229, 12.1384896
 TEAG DE-Hermsdorf Rodaer Straße 72, 50.8864278, 11.8501822
 TEAG DE-Schleiz Autohof, 50.551565, 11.789977
 
+Threeforce DE-Aschendorf In der Emsmarsch 1-7, 53.0490595625, 7.3212071875
+Threeforce DE-Aurich Tjüchkampstraße 4A, 53.440542, 7.515881
+Threeforce DE-Babenhausen An der Stadtmauer 5, 49.962623, 8.954204
+Threeforce DE-Bad Zwischenahn Ocholter Straße 10a, 53.188187, 7.967912
+Threeforce DE-Barßel Gewerbepark 19, 53.128699035686, 7.7698788036029
+Threeforce DE-Birkenfeld Hochwaldstraße 2, 49.650445, 7.156906
+Threeforce DE-Bützow Vor dem Rühner Tor, 53.848315, 11.976961
+Threeforce DE-Darmstadt Kasinostraße 96 A, 49.88349, 8.64835
+Threeforce DE-Daun Rosenbergstraße, 50.196868, 6.828973
+Threeforce DE-Dörpen Industriestr. 6, 52.971251, 7.36132
+Threeforce DE-Dörpen Neudörpener Straße 48-52, 52.962762, 7.343597
+Threeforce DE-Dötlingen Wildeshauser Straße 34, 52.909068, 8.440449
+Threeforce DE-Einhausen In der Wolfshecke 1, 49.663796, 8.543574
+Threeforce DE-Emden Nesserlander Str. 73-74, 53.355985, 7.194618
+Threeforce DE-Ensch Moselstr. 10, 49.828045, 6.834436
+Threeforce DE-Esens Am Hafen 21a, 53.677238, 7.575684
+Threeforce DE-Füssen Enzensbergstr. 5, 47.609334, 10.682689
+Threeforce DE-Goch Am Bössershof 2  - Hagebaumarkt 1, 51.665142, 6.173791
+Threeforce DE-Goch Reeser Straße, 51.616942, 6.211894
+Threeforce DE-Griesheim Groß-Gerauer Straße 1, 49.86002, 8.55526
+Threeforce DE-Hamburg Wesselblek 8, 53.639394, 10.057397
+Threeforce DE-Haren (Ems) Boschstraße 3, 52.796565, 7.214891
+Threeforce DE-Haselünne Heideweg 23, 52.665357, 7.394662
+Threeforce DE-Heidesheim Im Schäfersborn 6, 50.000134, 8.130028
+Threeforce DE-Karlsdorf-Neuthard Im Ochsenstall 12, 49.14781, 8.551993
+Threeforce DE-Köln Oskar-Jäger-Strasse 170, 50.947786, 6.907887
+Threeforce DE-Landau in der Pfalz Albert-Einstein-Straße 4, 49.187746, 8.132734
+Threeforce DE-Lengerich Tannenkämpe 28, 52.544077, 7.504697
+Threeforce DE-Lingen Rheiner Str. 43-45 + 55, 52.512086, 7.316853
+Threeforce DE-Lottstetten Industriestr.8, 47.633907, 8.581201
+Threeforce DE-Lübben Frankfurter Straße 82, 51.948563, 13.917748
+Threeforce DE-Luhden Hainekamp 2, 52.230441, 9.087431
+Threeforce DE-Lüneburg Zeppelinstraße 1 a, 53.248117, 10.467551
+Threeforce DE-Michelstadt Am Festplatz 3a, 49.679429, 9.001054
+Threeforce DE-Mörlenbach Schmittgasse 1, 49.599732, 8.736956
+Threeforce DE-München Eberwurzstr. 28, 48.197442, 11.555447
+Threeforce DE-Nordhorn Ernst-Heinkel-Straße 2, 52.463691, 7.161117
+Threeforce DE-Ober Mörlen Hasselhecker Str. 37, 50.363917, 8.692
+Threeforce DE-Ockenfels Burgstraße, 50.576494, 7.272906
+Threeforce DE-Papenburg An der Alten Werft 5, 53.086372, 7.382841
+Threeforce DE-Papenburg Friederikenstraße 100, 53.073811, 7.382591
+Threeforce DE-Papenburg Gerader Weg 3, 53.074941, 7.413269
+Threeforce DE-Papenburg Siemensstraße 19 - 21, 53.095201, 7.405509
+Threeforce DE-Pronsfeld Lünebacher Str., 50.156703, 6.338922
+Threeforce DE-Selmsdorf Ihlenberg 1, 53.871328986321, 10.877220049829
+Threeforce DE-Steinbach Ts. Waldstraße 71, 50.1776435, 8.5618645
+Threeforce DE-Stemwede-Levern Leverner Straße 6, 52.383782, 8.445533
+Threeforce DE-Stemwede-Levern Schröttinghauser Str. 23-24, 52.37206, 8.44677
+Threeforce DE-Thuine Zur Sunderinge 1, 52.503786, 7.479599
+Threeforce DE-Völklingen Stadionstrasse 1, 49.251810558594, 6.8605390390625
+Threeforce DE-Weiterstadt Max-Planck Straße 3, 49.898207, 8.593697
+Threeforce DE-Wildeshausen Buchbinderstraße 1, 52.887098, 8.413097
+Threeforce DE-Wolfsburg Brandgehaege, 52.369121, 10.731178
+Threeforce DE-Wuppertal Unten Vorm Steeg, 51.236613, 7.096498
+
 TotalEnergies BE-Kalken E17 Dir Antwerpen,51.07041,3.919857,80
 TotalEnergies BE-Total Bierges E411 Dir Arlon,50.71784402,4.583293224,80
 TotalEnergies BE-Total Bierges E411 Dir Bruxelles,50.71891302,4.584525999,80

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -7188,8 +7188,194 @@ Mer NO-Tromsø, 69.67366,18.923151
 MOL CZ-Bělčice, 49.840839,14.813349
 MOL CZ-Velké Němčice, 49.010451,16.686846,10
 MOL CZ-Velké Meziříčí, 49.345539,16.040024
-
+NewMotion DE-Ahrensfelde Karower Weg, 52.601114, 13.514322
+NewMotion DE-Aschaffenburg Schillerstr., 49.986982, 9.140212
+NewMotion DE-Asperg Ludwigsburger Strasse, 48.897212, 9.153987
+NewMotion DE-Bad Segeberg Ziegelstraße, 53.946743, 10.303729
+NewMotion DE-Bakum Harmerstraße, 52.725905, 8.178164
+NewMotion DE-Bayreuth , 49.962784000828, 11.611077999634
+NewMotion DE-Berlin Am Juliusturm, 52.536643, 13.22178
+NewMotion DE-Berlin Askanierring, 52.54766, 13.19431
+NewMotion DE-Berlin Bahnhofstraße, 52.386944, 13.407913
+NewMotion DE-Berlin Buchberger Str., 52.507126, 13.486209
+NewMotion DE-Berlin Gerichtstrasse, 52.543034, 13.378302
+NewMotion DE-Berlin Glienicker Str., 52.438065, 13.563606
+NewMotion DE-Berlin Hermsdorfer Damm, 52.615874, 13.300828
+NewMotion DE-Berlin Hohenzollerndamm, 52.488568, 13.306623
+NewMotion DE-Berlin Hultschiner Damm, 52.48624, 13.60406
+NewMotion DE-Berlin Jülicher Straße, 52.554718, 13.392017
+NewMotion DE-Berlin Königsbergerstrasse, 52.429633, 13.322253
+NewMotion DE-Berlin Konrad-Wolf-Str., 52.543332, 13.490347
+NewMotion DE-Berlin Maerkische Allee, 52.521295, 13.540666
+NewMotion DE-Berlin Manteuffelstr., 52.464703, 13.377156
+NewMotion DE-Berlin Mariendorfer Damm, 52.436121, 13.38851
+NewMotion DE-Berlin Marienfelder Chaussee, 52.42102, 13.426173
+NewMotion DE-Berlin Oranienburger Straße, 52.589907, 13.334708
+NewMotion DE-Berlin Oranienstraße, 52.504113, 13.408182
+NewMotion DE-Berlin Revaler Str., 52.506007, 13.459846
+NewMotion DE-Berlin Rothenbachstrasse, 52.571588, 13.429539
+NewMotion DE-Berlin Rummelsburger Landstraße, 52.480663993652, 13.502368
+NewMotion DE-Berlin Scharnweberstrasse, 52.567747820312, 13.309254171875
+NewMotion DE-Berlin Skalitzer Straße, 52.499211, 13.433126
+NewMotion DE-Berlin Wollankstr., 52.566029, 13.394896
+NewMotion DE-Bielefeld Artur Ladebeck Strasse, 52.010675, 8.519175
+NewMotion DE-Bochum Bernecker Straße, 51.452367, 7.224979
+NewMotion DE-Braunschweig Hans-Sommer-Straße, 52.2773, 10.54958
+NewMotion DE-Braunschweig Thiedestr. 30, 52.220612, 10.501914
+NewMotion DE-Bremen Osterholzer Herrstraße, 53.057775, 8.962478
+NewMotion DE-Bremerhaven Frederikshavener Str., 53.497197, 8.624916
+NewMotion DE-Broderstorf Mecklenburger Straße, 54.080813, 12.213006
+NewMotion DE-Bünde Osnabrücker Str., 52.192749, 8.557641
+NewMotion DE-Bütow Röbeler Chaussee, 53.361190966309, 12.496843039063
+NewMotion DE-Chemnitz Jagdschänkenstr., 50.812824000244, 12.84174
+NewMotion DE-Chemnitz Otto-Thörner Str., 50.808451, 12.969793
+NewMotion DE-Coswig Rosslauer Strasse, 51.88446, 12.43346
+NewMotion DE-Crailsheim Werner-von-Siemens-Strasse, 49.141101, 10.085099
+NewMotion DE-Düsseldorf Aufm Hennekamp, 51.202331, 6.780837
+NewMotion DE-Dahlwitz-Hoppegarten Lindenallee, 52.515371, 13.6695
+NewMotion DE-Döbeln Mastener Strasse, 51.122326, 13.101093
+NewMotion DE-Dogern Schnötstraße, 47.61413, 8.18281
+NewMotion DE-Dormagen Düsseldorfer Straße, 51.133679, 6.803495
+NewMotion DE-Dormagen Hamburger Strasse, 51.08997, 6.811625
+NewMotion DE-Dorsten Freudenbergstrasse, 51.702254, 6.929781
+NewMotion DE-Dresden Hansastrasse, 51.081164, 13.739749
+NewMotion DE-Duisburg Moerser Str., 51.449352, 6.701238
+NewMotion DE-Düsseldorf Karlsruher Straße, 51.19754, 6.841547
+NewMotion DE-Düsseldorf Kölner Landstraße, 51.193695, 6.81333
+NewMotion DE-Düsseldorf Münsterstraße, 51.252735, 6.801829
+NewMotion DE-Eisenberg Jenaer Str., 50.971174, 11.875574
+NewMotion DE-Ellwangen An der Jagst, 48.967436, 10.127776
+NewMotion DE-Enzberg-Mühlacker B, 48.933677, 8.804939
+NewMotion DE-Essenbach Daimlerstrasse, 48.58663, 12.189633
+NewMotion DE-Forchheim Äussere Nürnberger Straße, 49.7029075625, 11.0612225
+NewMotion DE-Frankfurt Hanauer Landstraße, 50.122654, 8.741379
+NewMotion DE-Freiburg Habsburger Strasse, 48.010631, 7.85494
+NewMotion DE-Fürstenwalde Trebuser Strasse, 52.369389, 14.060061
+NewMotion DE-Gera Ronneburger Strasse, 50.881248, 12.120393
+NewMotion DE-Gernsheim Robert-Bunsen-Str., 49.76941, 8.495824
+NewMotion DE-Gochsheim Schweinfurter Strasse, 50.02187625, 10.274728
+NewMotion DE-Goldberg Plauer Chaussee, 53.58347, 12.090411
+NewMotion DE-Göppingen Heiningerstrasse, 48.695946, 9.664917
+NewMotion DE-Graefenroda Waldstrasse, 50.748188, 10.811839
+NewMotion DE-Gransee Oranienburger Straße, 52.999096, 13.155411
+NewMotion DE-Großschirma Leipziger Str., 50.987258, 13.27456
+NewMotion DE-Haltern Recklinghäuser Strasse, 51.73259, 7.187081
+NewMotion DE-Hamburg Ahrensburger Straße, 53.578119, 10.093346
+NewMotion DE-Hamburg Alsterkrugchaussee, 53.62142, 10.009693
+NewMotion DE-Hamburg Amsinckstrasse, 53.543193, 10.021751
+NewMotion DE-Hamburg Bramfelder Chaussee, 53.622128, 10.08385
+NewMotion DE-Hamburg Bremer Str., 53.451866, 9.971204
+NewMotion DE-Hamburg Friedrich-Ebert-Damm, 53.589533, 10.100344
+NewMotion DE-Hamburg Georgswerder Bogen, 53.518477, 10.022768
+NewMotion DE-Hamburg Harksheider Straße, 53.662735, 10.079054
+NewMotion DE-Hamburg Hohe-Schaar-Str., 53.480024, 9.980666
+NewMotion DE-Hamburg Jüthornstrasse, 53.56687, 10.075444
+NewMotion DE-Hamburg Königstrasse, 53.548746, 9.944056
+NewMotion DE-Hamburg Schiffbeker Weg, 53.548618, 10.108415
+NewMotion DE-Hamburg Schnackenburgallee, 53.573534, 9.919157
+NewMotion DE-Hamburg Volksparkstraße, 53.591902, 9.921498
+NewMotion DE-Hamburg Winterhuder Weg, 53.573987, 10.023361
+NewMotion DE-Hannover Groß Buchholzer Straße, 52.397483, 9.794268
+NewMotion DE-Hannover Wülfeler Straße, 52.338114, 9.812848
+NewMotion DE-Hassloch Richard-Sang-Straße, 49.378684, 8.251626
+NewMotion DE-Hemmingen Göttinger Straße, 52.309462, 9.733592
+NewMotion DE-Hinterweidenthal Kaltenbach B, 49.200433, 7.74813
+NewMotion DE-Hockenheim Max-Planck-Strasse, 49.311163, 8.558715
+NewMotion DE-Hohen Neuendorf Berliner Straße, 52.660075, 13.28714
+NewMotion DE-Husum Robert-Koch-Str., 54.493082, 9.085125
+NewMotion DE-Illertissen Memminger Str., 48.217235, 10.103004
+NewMotion DE-Itzehoe Lindenstraße, 53.932372, 9.482678
+NewMotion DE-Kahl am Main Aschaffenburger Strasse, 50.06338675, 9.00495775
+NewMotion DE-Karlsfeld Münchner Str., 48.224490999981, 11.468557000492
+NewMotion DE-Kiel Hamburger Chaussee, 54.301019, 10.108457
+NewMotion DE-Kirchberg Schneeberger Straße, 50.622718, 12.531217
+NewMotion DE-Kirchentellinsfurt Kusterdinger Strasse, 48.532178, 9.137909
+NewMotion DE-Kirchheim Unter Teck Dettinger Str., 48.641912, 9.452371
+NewMotion DE-Kitzingen Repperndorfer Strasse 6, 49.738797, 10.152863
+NewMotion DE-Koeln Heidestraße, 50.858564, 7.098947
+NewMotion DE-Köln Godorfer Hauptstraße, 50.853119, 6.975777
+NewMotion DE-Köln Hugo-Eckener-Straße, 50.977356, 6.895473
+NewMotion DE-Köln Rösrather Straße, 50.920718, 7.092956
+NewMotion DE-Krefeld Glockenspitz, 51.336732, 6.604345
+NewMotion DE-Kronau Am Autobahnzubringer, 49.224395, 8.611685
+NewMotion DE-Laatzen Oesseler Str., 52.275098, 9.847645
+NewMotion DE-LÃ¶ffingen Studerstraße, 47.8862, 8.361013
+NewMotion DE-Lambsheim Mühltorstraße, 49.509695, 8.285538
+NewMotion DE-Landau Weissenburger Str, 49.185341, 8.113813
+NewMotion DE-Langenau Am Kiesgräble, 48.493015171875, 10.1080130625
+NewMotion DE-Langen Mörfelder Landstraße, 49.993087, 8.651978
+NewMotion DE-Lübeck Brandenbaumer Ldstr., 53.85804, 10.734611
+NewMotion DE-Lübeck Padelügger Weg, 53.856188, 10.636192
+NewMotion DE-Ludwigsfelde Parkallee, 52.308997, 13.313482
+NewMotion DE-Ludwigshafen Edigheimer Str., 49.526263, 8.398546
+NewMotion DE-Ludwigshafen Val-Bauer-Str, 49.479074, 8.426231
+NewMotion DE-Lüneburg Erbstorfer Landstraße, 53.261975, 10.42575
+NewMotion DE-Lünen Kurt-Schumacher-Str., 51.606697, 7.525679
+NewMotion DE-Mainz Geschwister-Scholl-Straße, 49.980589, 8.269525
+NewMotion DE-Mainz Obere Kreuzstraße, 50.014336, 8.218329
+NewMotion DE-Mannheim Normannenstr., 49.499024, 8.556933
+NewMotion DE-Merseburg Amtshäuser Strasse, 51.35887, 12.017598
+NewMotion DE-Merzig Merziger Straße, 49.441972, 6.622722
+NewMotion DE-Mittenwalde Dahmestrasse, 52.263441, 13.571675
+NewMotion DE-Monheim Heinrich-Hertz-Straße, 51.115728, 6.905965
+NewMotion DE-Müllheim Schliengener Str., 47.808832, 7.606175
+NewMotion DE-München Verdistraße, 48.165148, 11.46703
+NewMotion DE-Nettetal Steyler Straße, 51.326318, 6.178172
+NewMotion DE-Niendorf Schönberger Land, 53.81437, 10.877604
+NewMotion DE-Nuernberg Erlenstegenstrasse, 49.468990000002, 11.129440000003
+NewMotion DE-Nürnberg Frankenstrasse, 49.430935, 11.100845
+NewMotion DE-Oberhausen Centroallee, 51.48728, 6.875931
+NewMotion DE-Oberhausen Kirchhellener Straße, 51.537955, 6.863974
+NewMotion DE-Oberhausen-Rheinhausen Weiherweg, 49.265928, 8.478046
+NewMotion DE-Osnabrück Sutthauser Straße, 52.249262, 8.037469
+NewMotion DE-Ötigheim Haendelstrasse, 48.8884, 8.2443
+NewMotion DE-Petershagen/Eggersdorf Mierwerder Weg, 52.519574, 13.769402
+NewMotion DE-Pinneberg Rellinger Straße, 53.6482219375, 9.82094875
+NewMotion DE-Pirna Remscheider Straße, 50.952642, 13.957052
+NewMotion DE-Plochingen Esslinger Straße, 48.715688, 9.413767
+NewMotion DE-Quickborn Friedrichsgaber Straße, 53.749886, 9.934539
+NewMotion DE-Rampe Cambser Straße, 53.687225, 11.488314
+NewMotion DE-Ramstein-Miesenbach In der Watt, 49.423676, 7.559454
+NewMotion DE-Rheinau-Freistett Baron-Kückh-Straße, 48.661867, 7.937931
+NewMotion DE-Rosbach Raiffeisenstrasse, 50.29546, 8.685885
+NewMotion DE-Rostock Lorenzstraße, 54.109866, 12.168302
+NewMotion DE-Russelsheim Rugbyring, 49.987111, 8.402375
+NewMotion DE-Rutesheim Magarete-Steiff-Straße, 48.810793, 8.927205
+NewMotion DE-Saarbrücken Provinzialstrasse, 49.205096, 7.055637
+NewMotion DE-Salzgitter Kampstrasse, 52.14686, 10.322179
+NewMotion DE-Salzgitter Vor dem Dorfe, 52.140317, 10.33574
+NewMotion DE-Samtens Bergener Strasse, 54.361911, 13.30821
+NewMotion DE-Schleusingen Suhler Strasse, 50.519344109375, 10.754400171875
+NewMotion DE-Schönefeld Wassmannsdorfer, 52.367875, 13.46732
+NewMotion DE-Schwarzheide Schipkauer Str., 51.470787, 13.868435
+NewMotion DE-Schwielowsee Hauffstr., 52.363337, 12.972033
+NewMotion DE-Solingen Landwehr, 51.131561, 6.997389
+NewMotion DE-Stade Harsefelder Strasse, 53.584879, 9.471977
+NewMotion DE-Stockach Messkircher Str., 47.858429, 9.0043620000001
+NewMotion DE-Straelen Wankumer Str., 51.432244, 6.274254
+NewMotion DE-Stuttgart Burgstallstrasse, 48.755683, 9.141706
+NewMotion DE-Stuttgart Industristraße, 48.723155, 9.126018
+NewMotion DE-Stuttgart Neckartalstrasse, 48.819245, 9.226927
+NewMotion DE-Sulzbach a.d. Murr Milchstraße, 49.004417, 9.503938
+NewMotion DE-Syke Nienburger Strasse, 52.911474, 8.828416
+NewMotion DE-Templin Zehdenicker Strasse, 53.10342, 13.477354
+NewMotion DE-Ulm Blaubeurer Straße, 48.400956, 9.95564
 NewMotion DE-Unterschleißheim,48.272108,11.591192
+NewMotion DE-Velten Rosa-Luxemburg-Strasse, 52.684872, 13.181666
+NewMotion DE-Waldsee Schlichtstraße, 49.405271, 8.435716
+NewMotion DE-Waren Strelitzer Strasse, 53.51907, 12.71684
+NewMotion DE-Wedemark Hessenweg, 52.553147, 9.776761
+NewMotion DE-Wendlingen Heinrich-Otto-Str., 48.674262, 9.37177
+NewMotion DE-Witzhave Mollner Landstrasse, 53.56657, 10.331279
+NewMotion DE-Wolfsburg Braunschweiger Strasse, 52.412062, 10.782458
+NewMotion DE-Wolfsburg Heinrich-Nordhoff Str., 52.426317, 10.768746
+NewMotion DE-Wolfsburg Nordsteimker Strasse, 52.41767375, 10.8051095
+NewMotion DE-Wörrstadt Friedrich-Ebert-Straße, 49.845298, 8.112766
+NewMotion DE-Wuppertal Obere Lichtenplatzer Str., 51.248821, 7.192313
+NewMotion DE-Wuppertal Schmiedestr., 51.308124, 7.252308
+NewMotion DE-Würzburg Schweinfurter Str., 49.799179, 9.946465
+NewMotion DE-Zarrentin am Schaalsee Hauptstraße, 53.55196, 10.915517
+NewMotion DE-Zossen Stubenrauchstraße, 52.227392, 13.444821
 
 Pfalzwerke DE-Achern Severinstraße 8 , 48.634319058819, 8.0600501126866
 Pfalzwerke DE-Adelsheim Untere Austraße 38 , 49.396887, 9.393617

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -7871,6 +7871,58 @@ Mer NO-Tromsø, 69.67366,18.923151
 MOL CZ-Bělčice, 49.840839,14.813349
 MOL CZ-Velké Němčice, 49.010451,16.686846,10
 MOL CZ-Velké Meziříčí, 49.345539,16.040024
+
+MOON DE-Augsburg Donaustraße 8, 48.375551, 10.931804
+MOON DE-Bad Kötzting Lehmgasse 14, 49.173259, 12.865033
+MOON DE-Balingen Auf Stetten 4, 48.263933072723, 8.8462780479839
+MOON DE-Berlin Marzahner Chaussee 222, 52.528187, 13.53459
+MOON DE-Berlin-Marzahn Marzahner Chaussee 234, 52.531431, 13.532233
+MOON DE-Berlin-Tegel Berliner Straße 68, 52.581644104492, 13.291402010742
+MOON DE-Berlin-Tempelhof Oberlandstraße 36-41, 52.464084, 13.404469
+MOON DE-Berlin-Zehlendorf Goerzallee 251, 52.41610190625, 13.282978859375
+MOON DE-Chemnitz Müllerstraße 46, 50.845394546921, 12.920700599529
+MOON DE-Chemnitz Röhrsdorfer Allee 8, 50.86717971405, 12.856854000893
+MOON DE-Dresden Kesselsdorfer Straße 300, 51.040041, 13.648574
+MOON DE-Frankfurt am Main Hügelstraße 21, 50.149091, 8.677622
+MOON DE-Frankfurt am Main Strahlenberger Weg 30, 50.103814, 8.705839
+MOON DE-Frankfurt Mainzer Landstraße 406, 50.102222178971, 8.6236597672603
+MOON DE-Freiburg im Breisgau Tullastraße 55, 48.02355, 7.85006
+MOON DE-Gersthofen Augsburger Straße 51-53, 48.417579, 10.878659
+MOON DE-Gießen Grünberger Straße 49, 50.584666, 8.688897
+MOON DE-Gießen Zeppelinstraße 3, 50.592795443809, 8.7144685560518
+MOON DE-Hamburg Bornkampsweg 2-4, 53.565104, 9.919498
+MOON DE-Hamburg Fruchtallee 29, 53.569186484375, 9.9581889804688
+MOON DE-Hamburg Horner Landstraße 40, 53.552643, 10.07022
+MOON DE-Hamburg Kollaustraße 41, 53.603251, 9.961645
+MOON DE-Hamburg Langenhorner Chaussee 666, 53.678984, 10.001324
+MOON DE-Hamburg Wiesendamm 120, 53.589476132812, 10.023330416016
+MOON DE-Hamm Hammer Straße 144, 51.690282, 7.762736
+MOON DE-Hanau Donaustraße 32, 50.151624, 8.933269
+MOON DE-Hannover Hildesheimer Straße 349, 52.330209, 9.775608
+MOON DE-Hannover Podbielskistraße 295, 52.404157, 9.793684
+MOON DE-Landkern Hauptstraße 52, 50.193705, 7.153764
+MOON DE-Lehrte Rudolf-Petzold-Ring 1, 52.395961, 9.97256
+MOON DE-Leipzig Merseburger Straße 200, 51.344061285492, 12.298669429199
+MOON DE-Leipzig Torgauer Straße 331, 51.368312719543, 12.461156695923
+MOON DE-Lindau Riggersweilerweg 5, 47.565034, 9.70615
+MOON DE-Mannheim Weinheimer Straße 74, 49.508247, 8.525648
+MOON DE-München Frankfurter Ring 218, 48.185916, 11.604638
+MOON DE-München Frankfurter Ring 251, 48.186579, 11.608236
+MOON DE-München Georg-Brauchle-Ring 71, 48.176194, 11.527045
+MOON DE-München Landsberger Straße 240, 48.14281, 11.509607
+MOON DE-München Schatzbogen 37, 48.134447, 11.665165
+MOON DE-München Wasserburger Landstraße 5-11, 48.121148, 11.666611
+MOON DE-München Wasserburger Landstraße 69, 48.119354, 11.67999
+MOON DE-Ottobrunn Rosenheimer Landstraße 112, 48.055591, 11.667272
+MOON DE-Penzberg Seeshaupter Straße 19, 47.759932, 11.368576
+MOON DE-Potsdam Gerlachstraße 47-49, 52.371656, 13.139321
+MOON DE-Senden Zum Baggersee 1, 48.319281, 10.049636
+MOON DE-Sonthofen Illerstraße 19, 47.522448, 10.263003
+MOON DE-Stuttgart Hauptstraße 166, 48.732652, 9.092476
+MOON DE-Stuttgart Wangener Straße 66, 48.780972, 9.226934
+MOON DE-Ulm Schillerstraße 5A, 48.393402711113, 9.9830042468872
+MOON DE-Weilheim in Oberbayern Olympiastraße 4-8, 47.845602, 11.14894
+
 NewMotion DE-Ahrensfelde Karower Weg, 52.601114, 13.514322
 NewMotion DE-Aschaffenburg Schillerstr., 49.986982, 9.140212
 NewMotion DE-Asperg Ludwigsburger Strasse, 48.897212, 9.153987


### PR DESCRIPTION
Added the following missing charging stations with at least 50 kW in DE from the following operators:
- Porsche
- BP
- Kaufland
- The New Motion
- Compleo
- EDEKA
- ChargePoint
- ALDI
- Volkswagen
- LichtBlick
- MOON
- Threeforce

Tested live and no issues with invalid characters.