### PR TITLE
clean duplicate charging stations

### DIFF
--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -1521,7 +1521,6 @@ Allego DE-Barsbüttel Bauhaus, 53.576785,10.194484
 Allego DE-Barth Gewerbegebiet am Mastweg 8 , 54.359264, 12.711007
 Allego DE-Bayreuth Ludwig-Thoma-Straße  24 , 49.932966, 11.567755
 Allego DE-Bayreuth Sophian-Kolb-Straße 6 a , 49.957842, 11.601896
-Allego DE-Berg / Neumarkt Ludwig-Erhard-Ring 2 , 49.312984, 11.475445
 Allego DE-Bergkirchen Kreuzackerstraße 1 , 48.23857857145, 11.353796666842
 Allego DE-Berlin (Spandau)  Nonnendammallee 7 , 52.538496, 13.234371
 Allego DE-Berlin Abram-Joffe-Str. 18 , 52.43258, 13.527693
@@ -1577,7 +1576,7 @@ Allego DE-Dettelbach Mainfranken Park 21 , 49.778237284734, 10.069158310707
 Allego DE-Dorf Mecklenburg OT Karow Akazienstraße 1 , 53.852273, 11.457002
 Allego DE-Dorsten Gahlener Str. 306 , 51.657783, 6.904045
 Allego DE-Dortmund An der Buschmühle 1 , 51.494490967762, 7.469635481685
-Allego DE-Dortmund An der Buschmühle 1 , 51.49488, 7.47977
+Allego DE-Dortmund An den Wasserbecken , 51.49488, 7.47977
 Allego DE-Dresden ATU, 51.079151, 13.691018
 Allego DE-Dresden Hansastraße 72 , 51.083726795832, 13.739484331772
 Allego DE-Drochtersen Drochterser Str. 3 , 53.707788, 9.389123
@@ -1736,10 +1735,9 @@ Allego DE-Herford Engerstr. 171 , 52.12349, 8.636349
 Allego DE-Herford Salzufler Str. 21 , 52.112548, 8.683098
 Allego DE-Hermsdorf McDonalds, 50.889717, 11.872576, 10
 Allego DE-Herne Holsterhauser Straße 90 , 51.526774, 7.193069
-Allego DE-Herzsprung,53.067101,12.533024,4
 Allego DE-Heßdorf,49.6272,10.922888,10
 Allego DE-Hildesheim Bavenstedter Str. 71 , 52.164928, 9.97228
-Allego DE-Hilpoltstein, 49.161056, 11.260274, 7
+Allego DE-Hilpoltstein, 49.161056, 11.260274, 8
 Allego DE-Hilter Bielefelder Straße 35z , 52.13442, 8.150307
 Allego DE-Himmelkron Bayreuther Straße 3 , 50.056110596753, 11.609460900222
 Allego DE-Himmelkron Kulmbacher Straße 5 , 50.054078, 11.616755
@@ -1806,13 +1804,14 @@ Allego DE-Meschede Jahnstraße 48 , 51.355497, 8.285871
 Allego DE-Mettmann Marie-Curie-Str. 2 , 51.252237, 6.951764
 Allego DE-Mindelheim, 48.0352942, 10.501454
 Allego DE-Minden Sollingweg 32 , 52.308824, 8.842646
-Allego DE-Muenster Weseler Str. 535 , 51.92793, 7.587946
 Allego DE-Mönchengladbach Lemkuhlenweg 2 , 51.209898, 6.467789
 Allego DE-Mücke Gottesrain 2 , 50.645507559587, 8.9901355953655
 Allego DE-Mülheim/Ruhr  Weseler Str. 77 , 51.433012, 6.843968
 Allego DE-Münchberg, 50.20277, 11.77692, 4
 Allego DE-München Bodenseestraße 209 , 48.143433, 11.429782
+Allego DE-Münster Weseler Str. 535 , 51.92793, 7.587946
 Allego DE-Neuberg (Erlensee) Röntgenstraße 1, 50.182562, 9.006933
+Allego DE-Neumarkt Autohof, 49.312989, 11.475396, 5
 Allego DE-Neuruppin Wilhelm-Bartelt-Strasse  3 , 52.888557, 12.810769
 Allego DE-Nienburg/Weser Im Meerbachbogen 2 , 52.638019, 9.220892
 Allego DE-Nossen Im Industriegebiet 1 , 51.082719, 13.274013
@@ -1852,7 +1851,6 @@ Allego DE-Rostock Goerdelerstraße 52 , 54.099579, 12.072991
 Allego DE-Rostock Hagebaumarkt, 54.099039, 12.176245
 Allego DE-Rostock Handwerkstraße 1a , 54.124824, 12.074337
 Allego DE-Rostock Zum Südtor 6 , 54.13767, 12.114583
-Allego DE-Rühden, 51.947264, 10.140737, 3
 Allego DE-Saarbruecken Neumuehler Weg 83 , 49.205513, 7.020785
 Allego DE-Saarbrücken Gasweg 1 , 49.240842, 6.962856
 Allego DE-Satteldorf Marco-Polo-Straße  1 , 49.181481406223, 10.069496651777
@@ -1864,6 +1862,7 @@ Allego DE-Schoeneiche bei Berlin Kalkberger Str. 189 , 52.472636, 13.738215
 Allego DE-Schorfheide An der B167 6 , 52.849737, 13.68662
 Allego DE-Schweinfurt Friedrich-Rätzer-Str. 3 , 50.027888, 10.237882
 Allego DE-Schweitenkirchen, 48.510717, 11.582345, 3
+Allego DE-Seesen Autohof Rühden, 51.947264, 10.140737, 3
 Allego DE-Seevetal, 53.396642, 10.042457
 Allego DE-Selbitz Stegenwaldhauser Str. 1 , 50.32453275, 11.785000921875
 Allego DE-Sereetz Sereetzer Feld 1 , 53.926944, 10.722568
@@ -1902,6 +1901,7 @@ Allego DE-Wilhelmshaven Posener Straße 36-38 , 53.574008, 8.094087
 Allego DE-Windischeschenbach Am Gewerbepark  2A , 49.804537, 12.184248
 Allego DE-Winsen Osttangente 210 , 53.350665, 10.223448
 Allego DE-Wismar Kapitänspromenade 29-31 , 53.881171, 11.439219
+Allego DE-Wittstock/Dosse Jägerstraße 1 , 53.067164497463, 12.532995415919
 Allego DE-Wolfhagen Otto-Hahn-Str. 8 , 51.402576330719, 9.1868493937256
 Allego DE-Wolfsburg Braunschweiger Str. 204 , 52.401327, 10.752018
 Allego DE-Wolfsburg Westerlinge 8 , 52.423773, 10.732233
@@ -3375,8 +3375,6 @@ EnBW DE-Beckum Vellern Süd,51.79106,8.073932
 EnBW DE-Beimerstetten Heuweg, 48.480364, 9.980621
 EnBW DE-Bentheimer Wald Süd, 52.312502, 7.041832
 EnBW DE-Berg bei Neumarkt in der Oberpfalz An der Staatsstraße, 49.317329250529, 11.450465940093
-EnBW DE-Berge Ost , 48.984913, 10.196179
-EnBW DE-Berge West , 48.983091, 10.193419
 EnBW DE-Bergheim, 50.941999, 6.65236
 EnBW DE-Bergisch Gladbach Frankenforster Str., 50.955925, 7.13843
 EnBW DE-Bergisch Gladbach Obi, 50.992615, 7.119945
@@ -3454,6 +3452,7 @@ EnBW DE-Brandenburg an der Havel, 52.430611, 12.550501
 EnBW DE-Brandis, 51.32936, 12.58768
 EnBW DE-Braunsbach Marktplatz, 49.199483, 9.792348
 EnBW DE-Braunschweig Bauhaus, 52.215153059702, 10.530135736267
+EnBW DE-Braunschweig Hildesheimer Str. Bauhaus, 52.271380554369, 10.497192584704
 EnBW DE-Breitengüßbach, 49.973346, 10.87513
 EnBW DE-Bremen Bauhaus, 53.07245, 8.86271
 EnBW DE-Bremen Burger King, 53.053192, 8.74211
@@ -3526,7 +3525,6 @@ EnBW DE-Crailsheim In den Kistenwiesen, 49.14256, 10.073901
 EnBW DE-Cuxhaven, 53.875698, 8.688591
 EnBW DE-Dannenberg (Elbe), 53.09062, 11.08799
 EnBW DE-Darmstadt Otto-Röhm-Straße, 49.88729, 8.6443
-EnBW DE-Deffingen, 48.43331249, 10.2931190, 12
 EnBW DE-Deggenhausertal Tschasarteter Platz, 47.782307, 9.388458
 EnBW DE-Deizisau Altbacher Str., 48.715972, 9.389077
 EnBW DE-Deizisau Esslinger Straße, 48.714681, 9.379741
@@ -3543,7 +3541,6 @@ EnBW DE-Dessau-Roßlau, 51.82129, 12.30109
 EnBW DE-Dettenheim Ruchenstr., 49.183372, 8.423504
 EnBW DE-Dettingen Kirchheimer Str., 48.620229, 9.453779
 EnBW DE-Dettingen Rathausplatz, 48.528911, 9.34587
-EnBW DE-Dettingen an der Iller A7 Raststätte Illertal, 48.125490000007, 10.10954200124
 EnBW DE-Dieburg Frankfurter Straße, 49.909245, 8.849164
 EnBW DE-Dielheim Hauptstr., 49.282138, 8.735081
 EnBW DE-Dierdorf, 50.54583, 7.63511
@@ -3607,7 +3604,6 @@ EnBW DE-Eberstadt Backhausgasse, 49.178445, 9.32095
 EnBW DE-Eberswalde, 52.829874608775, 13.830185815442
 EnBW DE-Ebhausen Nagolder Str., 48.584699, 8.676206
 EnBW DE-Ebhausen Rathausstr., 48.60538, 8.662089
-EnBW DE-Edelzell, 50.529549,9.690535
 EnBW DE-Edertal, 51.171853, 9.106085
 EnBW DE-Edesheim Pfälzer Weinstraße Ost, 49.270394,8.153854, 10
 EnBW DE-Edesheim Pfälzer Weinstraße West, 49.26986,8.151913, 10
@@ -3628,6 +3624,8 @@ EnBW DE-Eisenberg (Pfalz) In den Geldäckern, 49.557312, 8.080851
 EnBW DE-Eisingen Talstraße, 48.9478693, 8.6691308
 EnBW DE-Ellhofen, 49.143621,9.308792
 EnBW DE-Ellwangen (Jagst) Doktor-Adolf-Schneider-Straße, 48.95421, 10.169293
+EnBW DE-Ellwangen (Jagst) Rasthof Ellwanger Berge Ost, 48.984851, 10.196098
+EnBW DE-Ellwangen (Jagst) Rasthof Ellwanger Berge West , 48.983091, 10.193419
 EnBW DE-Elmshorn, 53.74573, 9.66126
 EnBW DE-Elsterwerda, 51.465849, 13.533734
 EnBW DE-Elztal Nord , 50.266915808133, 7.2247688630885
@@ -3639,7 +3637,7 @@ EnBW DE-Endingen Freiburger, 48.138361, 7.703374
 EnBW DE-Endingen St.-Jakobs-Gässli, 48.142337, 7.70365
 EnBW DE-Endingen Wilhelm-Pfefferle-Str., 48.148052, 7.709592
 EnBW DE-Engelskirchen, 50.9861, 7.40839
-EnBW DE-Engen A81 Raststätte Hegau, 47.861479375, 8.78614403125
+EnBW DE-Engen A81 Raststätte Hegau, 47.861479375, 8.78614403125, 25
 EnBW DE-Engstingen Kirchstr., 48.386804, 9.284147
 EnBW DE-Engstingen Reutlinger Straße, 48.38521, 9.29783
 EnBW DE-Eningen Max-Planck-Str., 48.4775, 9.2428
@@ -3731,6 +3729,7 @@ EnBW DE-Friesoythe, 53.016216, 7.852262, 20
 EnBW DE-Frittlingen Weiherstr., 48.127357, 8.708149
 EnBW DE-Fronreute Hauptstraße, 47.863688, 9.588344
 EnBW DE-Fronreute Schwommengase, 47.864737, 9.589612
+EnBW DE-Fulda, 50.529408864729, 9.6904626647514
 EnBW DE-Fuldabrück, 51.272833230414, 9.5041947044464
 EnBW DE-Fürholzen Ost , 48.336792, 11.611033
 EnBW DE-Fürstenau, 52.5144, 7.686079
@@ -3804,7 +3803,6 @@ EnBW DE-Groß Schwülper, 52.354781, 10.44066
 EnBW DE-Groß-Umstadt Georg-August-Zinn-Straße, 49.87120420059, 8.9169126820666
 EnBW DE-Groß-Umstadt Kappesgärtenweg, 49.8727, 8.9281
 EnBW DE-Groß-Umstadt, 49.86928, 8.9198, 65
-EnBW DE-Großberg, 48.972829,12.065386
 EnBW DE-Großpösna, 51.2672521, 12.4987648
 EnBW DE-Großröhrsdorf, 51.154597, 14.02058
 EnBW DE-Grönegau Nord, 52.197118, 8.385565
@@ -3817,6 +3815,7 @@ EnBW DE-Gärtringen Nufringer Str., 48.625422, 8.923513
 EnBW DE-Göttingen West, 51.494746,9.876191
 EnBW DE-Göttingen tegut, 51.554899, 9.939627
 EnBW DE-Güglingen Stadtgraben, 49.067194, 9.000795
+EnBW DE-Günzburg Spielplatzstraße, 48.433351, 10.293138
 EnBW DE-Güstrow, 53.815456, 12.19278
 EnBW DE-Gütersloh, 51.900867, 8.404334
 EnBW DE-Haag in Oberbayern Gerberstraße, 48.16432, 12.167592
@@ -3903,7 +3902,7 @@ EnBW DE-Herschbach, 50.569133, 7.736197104
 EnBW DE-Hettstedt, 51.646759, 11.516185
 EnBW DE-Heusenstamm Werner-von-Siemens-Straße, 50.048875343503, 8.8004937189934
 EnBW DE-Heßdorf, 49.626625,10.923328, 30
-EnBW DE-Hildesheim Albert-Einstein-Str., 52.15948, 9.99422
+EnBW DE-Hildesheim Albert-Einstein-Str., 52.15948, 9.99422, 30
 EnBW DE-Hildesheim Prevo, 52.16312, 9.97213
 EnBW DE-Himmelpforten, 53.61389, 9.30104
 EnBW DE-Hirschaid Amlingstadter Straße, 49.828353, 10.989954
@@ -3942,6 +3941,7 @@ EnBW DE-Hürth, 50.88546, 6.89686
 EnBW DE-Hüttenberg, 50.521851844128, 8.5901397099196
 EnBW DE-Igersheim, 49.486855,9.820828
 EnBW DE-Illertal Ost, 48.124722, 10.112120, 20
+EnBW DE-Illertal West,48.125496,10.10963,20
 EnBW DE-Ilsfeld A81 Raststätte Wunnenstein, 49.044439272883, 9.2618000542973
 EnBW DE-Ilsfeld Porschestraße, 49.057791, 9.267089
 EnBW DE-Ilshofen Am Feuersee, 49.168867, 9.917508
@@ -4361,6 +4361,7 @@ EnBW DE-Pasewalk, 53.51465, 14.0108
 EnBW DE-Peine Penny, 52.31363, 10.22837
 EnBW DE-Peine Wilhelm-Rausch-Str., 52.339914715898, 10.247883629063
 EnBW DE-Penig, 50.92168985262, 12.714608773529
+EnBW DE-Pentling Ammerholz, 48.97292, 12.065341
 EnBW DE-Perl In der Dörrwiese, 49.474518, 6.373224
 EnBW DE-Petersberg, 50.968487, 11.854993
 EnBW DE-Petershagen, 52.37657, 8.95493
@@ -4955,6 +4956,7 @@ EVM DE-Cochem Bahnhofsvorplatz, 50.153328, 7.167515
 EVM DE-Koblenz Altstadt, 50.359981, 7.598084
 EVM DE-Koblenz Autohaus Löhr Becker, 50.378368, 7.585333
 EVM DE-Koblenz Autohaus Pretz, 50.334257, 7.6065574
+EVM DE-Koblenz Autohof Rübenacher Wald, 50.346812, 7.507836
 EVM DE-Koblenz Contel Hotel, 50.365908, 7.577220
 EVM DE-Koblenz Festung Ehrenbreitstein, 50.367221, 7.617626
 
@@ -5000,6 +5002,7 @@ EWE-GO DE-Bad Zwischenahn Am Hogen Hagen, 53.182726, 8.0151
 EWE-GO DE-Bad Zwischenahn Feldlinie, 53.17303, 8.06829
 EWE-GO DE-Bad Zwischenahn Hainbuchenweg, 53.16708, 8.15484
 EWE-GO DE-Bad Zwischenahn Heideweg, 53.1666, 8.15593
+EWE-GO DE-Bad Zwischenahn Langenhof, 53.181964, 8.002596
 EWE-GO DE-Bad Zwischenahn Oldenburger Straße, 53.18097, 8.022766
 EWE-GO DE-Bad Zwischenahn Pastor-Schulze-Straße, 53.182879, 7.998432
 EWE-GO DE-Bakum Bahnhofstraße, 52.73934, 8.19203
@@ -5016,8 +5019,10 @@ EWE-GO DE-Barßel Oldenburger Straße, 53.151186, 7.711911
 EWE-GO DE-Barßel Theodor-Klinker-Platz, 53.169091, 7.744814
 EWE-GO DE-Barßel Westmarkstraße, 53.166408, 7.736687
 EWE-GO DE-Bassum Bahnhofstraße, 52.846071, 8.73421
+EWE-GO DE-Bayreuth Sophian-Kolb-Straße, 49.95756, 11.60226
 EWE-GO DE-Bebra Gottlieb-Daimler-Straße, 50.962304, 9.790174
 EWE-GO DE-Bendorf Adolph-Kolping-Straße, 50.42631, 7.57001
+EWE-GO DE-Bensheim Wormser Straße, 49.67255, 8.59743
 EWE-GO DE-Bergisch Gladbach Richard-Zanders-Straße, 50.98502, 7.12195
 EWE-GO DE-Bergkamen Werner Straße, 51.6176, 7.65996
 EWE-GO DE-Berlin Charlottenburger Chaussee, 52.526533, 13.23301
@@ -5242,6 +5247,7 @@ EWE-GO DE-Geestland An der Burg, 53.625548, 8.84232
 EWE-GO DE-Geestland Dorfmitte, 53.676407, 8.68278
 EWE-GO DE-Geestland Handelspark, 53.627408, 8.810123
 EWE-GO DE-Geldern Weseler Straße, 51.52319, 6.34643
+EWE-GO DE-Gelsenkirchen Grothusstr., 51.521639752567, 7.073401732029
 EWE-GO DE-Gelsenkirchen Wickingstraße, 51.50334, 7.10798
 EWE-GO DE-Georgsmarienhütte Klöcknerstraße, 52.206117246094, 8.0587508007813
 EWE-GO DE-Germersheim Mainzer Straße, 49.227211, 8.371534
@@ -5263,6 +5269,7 @@ EWE-GO DE-Göttingen Siekweg, 51.52766, 9.88937
 EWE-GO DE-Hage Baantjebur, 53.601228, 7.282605
 EWE-GO DE-Hagen im Bremischen Am Neumarkt, 53.35953, 8.66188
 EWE-GO DE-Halberstadt Im Sülzeteiche, 51.88032, 11.0769
+EWE-GO DE-Haldensleben Johann-Gottlob-Nathusius-Straße, 52.28045, 11.432315
 EWE-GO DE-Halle (Saale) Rosenfelder Straße, 51.50131, 12.03321
 EWE-GO DE-Halle Magdeburger Chaussee, 51.52261, 11.95361
 EWE-GO DE-Hallstadt Emil-Kemmer-Straße, 49.91796, 10.87311
@@ -5435,6 +5442,7 @@ EWE-GO DE-Löningen Poststraße, 52.734376, 7.759257
 EWE-GO DE-Löningen Ringstraße, 52.742508, 7.759159
 EWE-GO DE-Löningen Tabbenstraße, 52.73443, 7.75663
 EWE-GO DE-Lübbecke Thyssenstraße, 52.32146, 8.62589
+EWE-GO DE-Lübbenau/Spreewald LPG-Straße, 51.84966, 13.90757
 EWE-GO DE-Lübeck Bei der Lohmühle, 53.880904, 10.673955
 EWE-GO DE-Lübeck Hinter den Kirschkaten, 53.848088, 10.677746
 EWE-GO DE-Lüdinghausen Valve, 51.76691, 7.45978
@@ -5449,9 +5457,11 @@ EWE-GO DE-Marktoberdorf Brückenstraße, 47.773399, 10.60495
 EWE-GO DE-Marktredwitz Böttgerstraße, 50.0134, 12.09918
 EWE-GO DE-Martfeld Hauptstraße, 52.876632, 9.062726
 EWE-GO DE-Massen-Niederlausitz Ludwig-Erhard-Straße, 51.63656, 13.73728
+EWE-GO DE-Meerane Hohe Straße, 50.841761, 12.44489
 EWE-GO DE-Meißen Fabrikstraße, 51.164993, 13.489314
 EWE-GO DE-Melle Industriestraße, 52.190412132036, 8.3527933577986
 EWE-GO DE-Menden Hämmerstraße, 51.450727, 7.752865
+EWE-GO DE-Mendig Ludwig-Erhard-Straße, 50.382029, 7.269635
 EWE-GO DE-Mering Hertzstraße, 48.273707, 10.97776
 EWE-GO DE-Mettmann Rudolf-Diesel-Straße, 51.25339, 6.95167
 EWE-GO DE-Minden Lübbecker Straße, 52.278228, 8.902649
@@ -5732,6 +5742,7 @@ EWE-GO DE-Werlte Unfriedstraße, 52.850166, 7.658131
 EWE-GO DE-Wermelskirchen Bandwirkerstr., 51.13692, 7.19943
 EWE-GO DE-Werne Nordlippestraße, 51.698298699989, 7.672388
 EWE-GO DE-Wernigerode Dornbergsweg, 51.85254, 10.79018
+EWE-GO DE-Wertheim Almosenberg, 49.77108, 9.58765
 EWE-GO DE-Westerholt Closterstraße, 53.58365, 7.46458
 EWE-GO DE-Westerholt Nordener Straße, 53.58969, 7.457914
 EWE-GO DE-Westerstede Am Hamjebusch, 53.256749, 7.935833
@@ -5747,6 +5758,7 @@ EWE-GO DE-Weyhe Im Bruch, 52.984732, 8.84356
 EWE-GO DE-Wiefelstede Kirchstraße, 53.25615, 8.11495
 EWE-GO DE-Wiesmoor Hauptstraße, 53.400672, 7.712459
 EWE-GO DE-Wiesmoor Kanalstr II, 53.39487, 7.70292
+EWE-GO DE-Wildenfels Arno-Schmidt-Straße, 50.68072, 12.59116
 EWE-GO DE-Wildeshausen Delmenhorster Straße, 52.902774869048, 8.4444769583328
 EWE-GO DE-Wildeshausen Gildeplatz, 52.896432, 8.438846
 EWE-GO DE-Wildeshausen Glaner Straße, 52.90179, 8.416729
@@ -5782,6 +5794,7 @@ EWE-GO DE-Zeitz Geußnitzer Straße, 51.03663, 12.16023
 EWE-GO DE-Zetel Neuenburger Straße, 53.41799, 7.972179
 EWE-GO DE-Zeven Kivinanstraße, 53.292162, 9.274971
 EWE-GO DE-Zwickau Oskar-Arnold-Straße, 50.70627, 12.50094
+EWE-GO DE-Zwickau Ost, 50.6807333, 12.591146, 10
 EWE-GO DE-Zülpich Villa Rustica, 50.704799, 6.669532
 EWE-GO DE-Überlingen Abigstraße, 47.774522, 9.186378
 
@@ -5809,6 +5822,7 @@ Fastned DE-Gießen Ferniestraße, 50.57151, 8.68999
 Fastned DE-Gladbeck-Ellinghorst, 51.5552, 6.96951
 Fastned DE-Goldbach, 49.993547,9.173447
 Fastned DE-Herbolzheim, 48.22685, 7.75509
+Fastned DE-Hermsdorf, 50.8897673, 11.8719638, 18
 Fastned DE-Hilden, 51.192201,6.935931,3
 Fastned DE-Hildesheim, 52.16083, 9.99676
 Fastned DE-Leutkirch im Allgäu Auf der, 47.83136, 10.00428
@@ -5964,10 +5978,13 @@ Ionity CZ-Pávov (dir. Brno), 49.453814, 15.591480
 Ionity CZ-Pávov (dir. Prague), 49.455104, 15.593272
 Ionity DE-Aachener Land Nord, 50.817668, 6.213854
 Ionity DE-Aachener Land Süd, 50.817306, 6.216629
+Ionity DE-Aalbek West, 54.092671, 9.92914
 Ionity DE-Altenburger Land Nord, 50.860662, 12.307977
 Ionity DE-Altenburger Land Süd, 50.85675, 12.3132
 Ionity DE-Am Fichtenplan Nord, 52.318183, 13.494709
 Ionity DE-Am Fichtenplan Süd, 52.315620, 13.494702
+Ionity DE-Auetal Nord, 52.223703, 9.221469
+Ionity DE-Auetal Süd, 52.226977, 9.232545
 Ionity DE-Augsburg Ost, 48.411614, 10.914898
 Ionity DE-Bad Camberg West, 50.299926, 8.234700
 Ionity DE-Bad Honnef, 50.647664, 7.334521
@@ -5979,45 +5996,81 @@ Ionity DE-Bochum, 51.474082, 7.151429
 Ionity DE-Brohltal Ost, 50.440471, 7.225629
 Ionity DE-Brohltal West, 50.441534, 7.223985
 Ionity DE-Brokenlande Ost, 54.014217, 9.93325
+Ionity DE-Bruchsal Ost, 49.162694, 8.570788
+Ionity DE-Bruchsal West, 49.16125, 8.567226
 Ionity DE-Buddikate Ost, 53.694396, 10.324738
 Ionity DE-Buddikate West, 53.692558, 10.320428
 Ionity DE-Castrop Rauxel Grutholzallee, 51.566342, 7.317542
 Ionity DE-Dammer Berge Ost, 52.539229, 8.114598
+Ionity DE-Dammer Berge West, 52.540755, 8.112701
+Ionity DE-Demminer Land, 53.855673, 13.333344
+Ionity DE-Denkendorf Hoher Rain, 48.693667, 9.303297
+Ionity DE-Denkendorf Nord, 48.693667, 9.303297
+Ionity DE-Dettelbach Mainfrankenpark, 49.777979, 10.068774
+Ionity DE-Dietingen Autobahn A 81, 48.20593, 8.621045
 Ionity DE-Dietmannsried Glaserstraße, 47.811904, 10.302936
+Ionity DE-Dollenberg Ost, 50.688524, 8.295916, 5
 Ionity DE-Donautal Ost, 48.588065, 13.366667
 Ionity DE-Donautal West, 48.589422, 13.365369
 Ionity DE-Dresdner Tor Nord, 51.063214, 13.571071
+Ionity DE-Dresdner Tor Süd, 51.060227, 13.571959
 Ionity DE-Eching Dieselstraße, 48.310848, 11.646729
+Ionity DE-Eichenzell, 50.488366, 9.708621, 8
+Ionity DE-Eifel Ost, 50.070186, 6.880905
+Ionity DE-Eifel West, 50.068492, 6.880212
+Ionity DE-Forst A5 Ost, 49.162694, 8.570788
+Ionity DE-Forst A5 West, 49.16125, 8.567226
 Ionity DE-Frankenhöhe Nord, 49.242629, 10.352944
 Ionity DE-Frankenhöhe Süd, 49.241155, 10.356121
 Ionity DE-Garching bei München Parkring, 48.249323, 11.634365
+Ionity DE-Goldbach Nord, 53.000606, 9.179514
+Ionity DE-Goldbach Süd, 52.998531, 9.181213
 Ionity DE-Gruibingen  Autobahn, 48.605321, 9.632807
 Ionity DE-Haidt Nord, 49.780852, 10.244797
 Ionity DE-Haidt Süd, 49.779352, 10.246493
 Ionity DE-Hamminkeln, 51.739103, 6.595180
 Ionity DE-Harz Ost, 51.926279, 10.143238
+Ionity DE-Harz West, 51.928028, 10.141730
+Ionity DE-Hausen bei Würzburg An der BAB A7 West, 49.945695, 10.016764
 Ionity DE-Heiligengrabe Liebenthaler Dorfstraße, 53.147243, 12.398704
 Ionity DE-Hepberg A9 Köschinger Forst, 48.837085, 11.469313
+Ionity DE-Himmelkron, 50.055972, 11.609148
+Ionity DE-Hohenlohe Nord, 49.207007, 9.639273
+Ionity DE-Hohenlohe Süd, 49.205379, 9.639696
+Ionity DE-Hohenwarsleben, 52.173898, 11.49512, 11
 Ionity DE-Holzkirchen Nord, 47.892208, 11.731279
 Ionity DE-Holzkirchen Süd, 47.906573, 11.717379
 Ionity DE-Illertissen, 48.219287,10.127852, 13
 Ionity DE-Kaiserslautern Mainzer Straße, 49.456353, 7.797315
+Ionity DE-Katzenfurt Süd, 50.620347, 8.362918, 5
 Ionity DE-Kirchheim (Tal), 50.833695, 9.5707772, 20
 Ionity DE-Kirchheim Burger King, 50.8332832, 9.5731819
 Ionity DE-Köschinger Forst Ost, 48.836599, 11.472234
 Ionity DE-Lechwiesen Nord, 48.059266, 10.846791
 Ionity DE-Lechwiesen Süd, 48.058328, 10.847694
+Ionity DE-Lehrter See Nord, 52.388762, 9.99631
+Ionity DE-Lehrter See Süd, 52.386433, 9.998919
 Ionity DE-Leinefelde-Worbis Ernemannstraße, 51.390739, 10.342552
 Ionity DE-Lichtendorf Nord, 51.468319, 7.594014
 Ionity DE-Lichtendorf Süd, 51.467751, 7.596959
 Ionity DE-Linthe Westfalenstraße, 52.160118, 12.779906
 Ionity DE-Lippetal, 51.695845, 7.966201
+Ionity DE-Lonetal Ost, 48.584246, 10.178939, 10
+Ionity DE-Lonetal West, 48.583937, 10.175605, 10
 Ionity DE-Lutterberg, 51.370342, 9.633558, 8
 Ionity DE-Lüneburger Heide Ost, 53.110044, 9.984058
+Ionity DE-Lüneburger Heide West, 53.109317, 9.981663
+Ionity DE-Mahlberg Ost, 48.308819, 7.791519
+Ionity DE-Mahlberg West, 48.309517, 7.788855
 Ionity DE-Meerane Hohe Straße, 50.840764, 12.445016
 Ionity DE-Merklingen Nellinger Str., 48.516511, 9.756944
 Ionity DE-Mühldorf am Inn Äußere Neumarkter Str, 48.262445, 12.542657
+Ionity DE-Neckarburg Ost, 48.206218, 8.627155
+Ionity DE-Neckarburg West, 48.20593, 8.621045
 Ionity DE-Nempitz, 51.290114,12.137547, 6
+Ionity DE-Neuenstein Lohemerfeld, 49.207007, 9.639273
+Ionity DE-Neumünster Prehnsfelder Weg, 54.092671, 9.92914
+Ionity DE-Niederöfflingen An der BAB A1, 50.068492, 6.880212
 Ionity DE-Oberhausen Brammenring, 51.489778, 6.887922
 Ionity DE-Oberkrämer Im Gewerbepark, 52.709772, 13.107945
 Ionity DE-Oelde In d. Geist, 51.812002, 8.131019
@@ -6031,8 +6084,10 @@ Ionity DE-Pilsting, 48.692530, 12.672979
 Ionity DE-Polch Im Roten Tal, 50.306876, 7.306114
 Ionity DE-Porta Westfalica Zum Autohof, 52.209983, 8.872595
 Ionity DE-Reinhardshain Nord, 50.622937, 8.894846
+Ionity DE-Reinhardshain Süd, 50.622096, 8.897196
 Ionity DE-Remscheid Ost, 51.158407, 7.230332
 Ionity DE-Riedener Wald Ost, 49.944184, 10.019955
+Ionity DE-Riedener Wald West, 49.945693, 10.016739
 Ionity DE-Rostock Timmermannsstrat, 54.083283, 12.19232
 Ionity DE-Salzbergen, 52.326149, 7.430067
 Ionity DE-Samerberg Nord, 47.802835, 12.178503
@@ -6042,14 +6097,18 @@ Ionity DE-Schwabhausen, 50.898384, 10.725625
 Ionity DE-Spessart Nord, 49.898302, 9.394346
 Ionity DE-Thüringer Wald Nord, 50.726454, 10.841634
 Ionity DE-Thüringer Wald Süd, 50.724708, 10.847168
+Ionity DE-Völschow Rastplatz Demminer Land E251, 53.855673, 13.333344
 Ionity DE-Weiskirchen Süd, 50.054708, 8.908177
 Ionity DE-Wernberg-Köblitz, 49.532356, 12.134910, 3
+Ionity DE-Wilsdruff Raststätte Dresdner Tor Süd A4 Richtung Ost, 51.060227, 13.571959
 Ionity DE-Wismar Am Ring, 53.893217, 11.513095
 Ionity DE-Wittlich Straßburgstraße, 49.966871, 6.942735
 Ionity DE-Wolfsburg Allerpark, 52.437710, 10.809069
 Ionity DE-Wolfsburg Braunschweiger Str., 52.416656, 10.783389
 Ionity DE-Wolfsburg Detmeroder Markt, 52.392241, 10.753713
 Ionity DE-Wolfsburg Forum AutoVision, 52.424872, 10.745689
+Ionity DE-Wunnenstein Ost, 49.045334, 9.266223
+Ionity DE-Wunnenstein West, 49.044276, 9.261639
 Ionity DK-Aabenraa, 55.065192, 9.366167
 Ionity DK-Fredericia, 55.53682, 9.7169
 Ionity DK-Greve, 55.58492, 12.258
@@ -6282,10 +6341,12 @@ Innogy DE-Berlin Alt-Mariendorf, 52.440133, 13.387033
 Innogy DE-Berlin Alt-Moabit, 52.523192, 13.362577
 Innogy DE-Berlin Alt-Rudow, 52.41626, 13.496625
 Innogy DE-Berlin Augsburger Str. 25 (ggü. Lang und, 52.501328, 13.335408
+Innogy DE-Berlin Avus, 52.501775, 13.277211
 Innogy DE-Berlin Bahnhofstr., 52.469967, 13.339781
 Innogy DE-Berlin Bayreuther Str., 52.501159, 13.343907
 Innogy DE-Berlin Bellevuestraße, 52.510384, 13.37361
 Innogy DE-Berlin Boyenstr., 52.535977, 13.36889
+Innogy DE-Berlin Brunsbütteler Damm, 52.533676, 13.174356
 Innogy DE-Berlin Charlottenburger Chaussee, 52.528134, 13.2264
 Innogy DE-Berlin Fasanenstr., 52.505042, 13.327423
 Innogy DE-Berlin Frankfurter Allee, 52.511752, 13.497569
@@ -6342,6 +6403,8 @@ Innogy DE-Brühl Renault-Nissan Straße, 50.843295, 6.904076
 Innogy DE-Buch Untere Straße, 48.223334, 10.178266
 Innogy DE-Buchloe Bahnhofstraße, 48.0358, 10.72347
 Innogy DE-Cloerbruch Nord, 51.237662, 6.513529
+Innogy DE-Cloerbruch Süd, 51.236686, 6.510928
+Innogy DE-Dannstadt-Schauernheim, 49.410297, 8.339979
 Innogy DE-Delmenhorst Reinersweg, 53.036667, 8.672222
 Innogy DE-Donauwörth Adolph-Kolping-Straße, 48.71649, 10.77942
 Innogy DE-Dortmund Altwickeder Hellweg, 51.533611, 7.624722
@@ -6371,6 +6434,7 @@ Innogy DE-Dortmund Wenzelstr Ecke, 51.489186, 7.502455
 Innogy DE-Dortmund Werner Straße, 51.499444, 7.333333
 Innogy DE-Dortmund Westerfilder Straße, 51.548117, 7.381117
 Innogy DE-Drensteinfurt Bahnhofsplatz, 51.799467, 7.733983
+Innogy DE-Duisburg, 51.484186, 6.763764
 Innogy DE-Elsdorf, 50.915, 6.591111
 Innogy DE-Erwitte Westerntor, 51.63079, 8.360218
 Innogy DE-Essen Altenessener Str., 51.466267, 7.013612
@@ -6398,6 +6462,7 @@ Innogy DE-Essen Zweigertstraße, 51.436525, 6.998903
 Innogy DE-Flammersfeld Rheinstraße, 50.646153, 7.523277
 Innogy DE-Fleringen Gewerbegebiet, 50.20975, 6.4904
 Innogy DE-Frankfurt am Main, 50.112730, 8.652925
+Innogy DE-Fürholzen West, 48.33747, 11.6081
 Innogy DE-Geldern Südwall, 51.516155, 6.322532
 Innogy DE-Goldbach Sachsenhausen, 49.997901, 9.181043
 Innogy DE-Grevenbroich Elfgener Dorfstraße, 51.083806, 6.553237
@@ -6407,6 +6472,7 @@ Innogy DE-Hattingen Augustastr., 51.399347, 7.186377
 Innogy DE-Hattingen Roonstraße /, 51.40115, 7.185217
 Innogy DE-Hemmingen , 48.86795, 9.041447
 Innogy DE-Horhausen , 50.589107, 7.529869
+Innogy DE-Hunsrück Ost, 49.963783, 7.768701
 Innogy DE-Hösbach Jahnstraße, 50.007214, 9.205869
 Innogy DE-Hückeswagen Auf'm Schloß, 51.150588, 7.341565
 Innogy DE-Hückeswagen Rader Straße, 51.153701, 7.341464
@@ -6421,6 +6487,7 @@ Innogy DE-Königsbrunn Alter Postweg, 48.270564, 10.884767
 Innogy DE-Königsforst Ost, 50.899387, 7.152103, 7
 Innogy DE-Kürten Odenthaler Straße, 51.040355, 7.207632
 Innogy DE-Lauingen Rudolf-Diesel-Ring, 48.576725, 10.447875
+Innogy DE-Leipheim, 48.437494, 10.213398
 Innogy DE-Leipzig Porschestr. 1 Bau, 51.405773, 12.295955
 Innogy DE-Ludwigsburg , 48.892726476075, 9.1709412380939
 Innogy DE-Ludwigsfelde Zum Röthepfuhl 1, 52.298889, 13.281667
@@ -6434,6 +6501,7 @@ Innogy DE-Mettmann Düsseldorfer Straße, 51.252, 6.9716
 Innogy DE-Michendorf Zum Weiher, 52.283611, 13.028056
 Innogy DE-Möhnesee Hauptstraße, 51.496778, 8.12878
 Innogy DE-Mülheim an der Ruhr Mellinghofer Strasse, 51.449975, 6.883106
+Innogy DE-Münsterland Ost, 51.942185, 7.551096
 Innogy DE-Münsterland West, 51.945622, 7.547827
 Innogy DE-Naumburg enviaM, 51.143017,11.824768
 Innogy DE-Neuenkirchen Alte Poststr., 52.418583, 7.83615
@@ -6451,6 +6519,7 @@ Innogy DE-Reichenbach Marienstraße, 50.621111, 12.298889
 Innogy DE-Reichenbach Roßplatz, 50.620556, 12.302222
 Innogy DE-Rhede Gildekamp, 51.840246, 6.69537
 Innogy DE-Ruderatshofen Am, 47.8032, 10.55061
+Innogy DE-Ruraue West, 50.929795, 6.337327
 Innogy DE-Sachsenheim Porscheplatz, 48.952045, 9.043545
 Innogy DE-Sankt Augustin Einsteinstraße, 50.791794, 7.178682
 Innogy DE-Schongau An der Fronveste, 47.815037, 10.897106
@@ -6473,6 +6542,7 @@ Innogy DE-Stuttgart-Zuffenhausen Lorenzstr., 48.833486185398, 9.1490431159086
 Innogy DE-Thannhausen Edmund-Zimmermann-Straße, 48.28195, 10.4707
 Innogy DE-Timmendorfer Strand Strandallee, 53.998729, 10.779577
 Innogy DE-Tor1 NORD , 51.410888174102, 12.294660999912
+Innogy DE-Tornesch Pendlerparkplatz, 53.718479, 9.759092, 15
 Innogy DE-Treuen, 50.549113, 12.286336
 Innogy DE-Unkel Kamener, 50.598541, 7.218679
 Innogy DE-Unna Heinrich-Hertz-Straße, 51.535701, 7.727683
@@ -6835,8 +6905,9 @@ Ladeverbund+ DE-Schwabach, 49.323136,11.042675
 Ladeverbund+ DE-Tauberbischofsheim, 49.630349,9.666165
 Ladeverbund+ DE-Wilhermsdorf, 49.481100,10.716472
 
-
+LEW DE-Deffingen, 48.433701, 10.292805, 10
 LEW DE-Friedberg Bäckerei Scharold, 48.4064614, 10.952062, 10
+LEW DE-Friedberg McDonald´s, 48.4073617, 10.952510, 10
 LEW DE-Jengen, 48.0034128, 10.721623
 LEW DE-Krumbach, 48.2450945, 10.3616606, 10
 LEW DE-Pfaffenhausen, 48.120746, 10.457604
@@ -7440,6 +7511,7 @@ Lidl DE-Offenau,49.2390735,9.1674555
 Lidl DE-Oldenburg-Donnerschwee Wehdestraße 10, 53.15044, 8.238054
 Lidl DE-Oldenburg-Wechloy Ammerländer Heerstraße 272, 53.156808, 8.170312
 Lidl DE-Oranienburg Berliner Straße 49, 52.74822, 13.236639
+Lidl DE-Oschersleben,52.0288961,11.2476357
 Lidl DE-Osnabrück Hannoversche Straße 19, 52.265123, 8.065501
 Lidl DE-Osnabrück Hans-Wunderlich-Straße 2, 52.267027, 8.001444
 Lidl DE-Osnabrück-Dodesheide Mönkedieckstraße 11-13, 52.299187, 8.061235
@@ -8313,6 +8385,7 @@ Porsche DE-Wuppertal Porschestraße, 51.3053, 7.25279
 
 Recharge FI-Sodankylä, 67.431695,26.57509
 
+REWE DE-Bremen, 53.136455, 8.739926
 
 schneller-strom-tanken DE-Ehingen, 48.284649, 9.721507
 schneller-strom-tanken DE-Dillingen, 48.579583, 10.496334
@@ -8327,6 +8400,7 @@ ShellRecharge DE-Berg, 50.372, 11.787795
 ShellRecharge DE-Kamen Karree, 51.568119, 7.674458
 ShellRecharge DE-Kirchheim, 50.8342519, 9.5744849, 10
 ShellRecharge DE-Kraftsdorf, 50.8959477, 11.9793605, 5
+ShellRecharge DE-Neu-Ulm, 48.3875766, 10.033160
 ShellRecharge DE-Osnabrück, 52.301747, 7.949302
 ShellRecharge NL-Heerlen, 50.823176, 6.019581, 30
 
@@ -8542,6 +8616,7 @@ TotalEnergies NL-Houten,52.02856801,5.131599354,80
 TotalEnergies NL-Kadoelen,52.41673049,4.912498327,80
 TotalEnergies NL-Kruisberg,50.88671064,5.739580901,80
 TotalEnergies NL-Leiderdorp Aurora,52.16004438,4.554247245,80
+TotalEnergies NL-Lelystad Aalscholver,52.43561752,5.425150192,80
 TotalEnergies NL-Leusden,52.14337952,5.417969669,80
 TotalEnergies NL-Maarheeze,51.32249303,5.593607509,80
 TotalEnergies NL-Marwijk Kooy,52.33474716,4.928431654,80

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -68,7 +68,7 @@ Supercharger BE-Aalst, 50.92147, 4.03275
 Supercharger BE-Antwerp, 51.268051, 4.4024, 70
 Supercharger BE-Antwerp-Aartselaar, 51.13699, 4.37719
 Supercharger-V3 BE-Arlon, 49.648129,5.818957
-Supercharger BE-Brugge, 51.16989, 3.19666
+Supercharger-V3 BE-Brugge, 51.16989, 3.19666
 Supercharger BE-Edegem, 51.151055, 4.432582
 Supercharger-V3 BE-Hasselt, 50.951748, 5.353142, 17
 Supercharger BE-Heusden-Zolder, 50.9934, 5.2422
@@ -270,7 +270,7 @@ Supercharger DE-Mogendorf, 50.4827719, 7.750309
 Supercharger-V3 DE-Montabaur,50.443591,7.830885,20
 Supercharger DE-Motten, 50.355621, 9.75384
 Supercharger-V3 DE-Murr, 48.956119,9.245459
-Supercharger DE-Mücke, 50.645442, 8.989816
+Supercharger-V3 DE-Mücke, 50.645442, 8.989816
 Supercharger DE-Mühldorf, 48.27257, 12.54995
 Supercharger-V3 DE-Münchberg-Nord, 50.202822,11.776624, 18
 Supercharger-V3 DE-München - Pasing Arcaden, 48.147909,11.464882
@@ -432,7 +432,7 @@ Supercharger ES-Zaragoza, 41.625707, -1.009618
 Supercharger FI-Äänekoski, 62.516741, 25.6913
 Supercharger FI-Akaa, 61.181106, 23.885075
 Supercharger-V3 FI-Hartola, 61.578409,26.009758
-Supercharger FI-Huittinen, 61.168436, 22.680099
+Supercharger-V3 FI-Huittinen, 61.168436, 22.680099
 Supercharger FI-Jalasjärvi,62.417071,22.791815
 Supercharger-V3 FI-Karesuvanto, 68.450226,22.4814
 Supercharger-V3 FI-Kempele, 64.9018031, 25.5353976
@@ -651,7 +651,7 @@ Supercharger-V3 IS-Kirkjubæjarklaustur, 63.789025,-18.052187
 Supercharger-V3 IS-Staðarskáli, 65.14475,-21.084813
 Supercharger-V3 IS-Vatnagardar, 64.14496,-21.854711
 Supercharger-V3 IT-Adda Sud,45.510724,9.63624
-Supercharger IT-Affi, 45.551296, 10.787143
+Supercharger-V3 IT-Affi, 45.551296, 10.787143
 Supercharger-V3 IT-Afragola - Napoli North, 40.93333064, 14.35741834
 Supercharger IT-Aosta, 45.73745, 7.371416
 Supercharger-V3 IT-Arese, 45.561371, 9.055905
@@ -832,7 +832,6 @@ Supercharger NO-Os, 60.192788, 5.4652
 Supercharger NO-Porsgrunn, 59.122098, 9.707564
 Supercharger NO-Rennebu, 62.832142, 10.010141
 Supercharger NO-Ringdalskogen, 59.112402, 10.108727
-Supercharger NO-Rolvsøy, 59.324292, 10.954448
 Supercharger NO-Rugtvedt, 59.035933, 9.67402
 Supercharger NO-Rygge, 59.38753, 10.751039
 Supercharger NO-Røldal, 59.816824, 6.752226
@@ -847,6 +846,7 @@ Supercharger-V3 NO-Skien,59.206742,9.6090613
 Supercharger NO-Skjåk, 61.88317, 8.267157
 Supercharger NO-Skulestadmo, 60.658297, 6.436256
 Supercharger NO-Svolvær, 68.233132, 14.559828
+Supercharger NO-Solli, 59.324292, 10.954448
 Supercharger NO-Stjørdal, 63.466385, 10.918098
 Supercharger-V3 NO-Stryn, 61.904677,6.7258
 Supercharger NO-Storjord, 66.814045, 15.401738

--- a/TeslaLogger/bin/geofence.csv
+++ b/TeslaLogger/bin/geofence.csv
@@ -10,7 +10,6 @@ Supercharger AT-Innsbruck, 47.264882, 11.428380
 Supercharger AT-Kapfenberg, 47.450188, 15.317675
 Supercharger AT-Kitzbühel, 47.459205, 12.386105
 Supercharger-V3 AT-Langkampfen, 47.534597, 12.092972
-Supercharger AT-Langkampfen, 47.534597, 12.092972
 Supercharger AT-Laßnitzhöhe, 47.070925, 15.578139
 Supercharger AT-Lermoos, 47.394965, 10.887519
 Supercharger AT-Lermoos, 47.395975, 10.887217
@@ -69,9 +68,7 @@ Supercharger BE-Aalst, 50.92147, 4.03275
 Supercharger BE-Antwerp, 51.268051, 4.4024, 70
 Supercharger BE-Antwerp-Aartselaar, 51.13699, 4.37719
 Supercharger-V3 BE-Arlon, 49.648129,5.818957
-Supercharger BE-Arlon, 49.648129,5.818957
 Supercharger BE-Brugge, 51.16989, 3.19666
-Supercharger-V3 BE-Brugge, 51.16989, 3.19666
 Supercharger BE-Edegem, 51.151055, 4.432582
 Supercharger-V3 BE-Hasselt, 50.951748, 5.353142, 17
 Supercharger BE-Heusden-Zolder, 50.9934, 5.2422
@@ -175,7 +172,6 @@ Supercharger-V3 DE-Bochum - Ruhr Park, 51.49506,7.28483
 Supercharger-V3 DE-Bonn - Bonner Bogen, 50.718553, 7.152138 
 Supercharger-V3 DE-Böblingen,48.69138,9.003647
 Supercharger-V3 DE-Braak, 53.6178758, 10.239352
-Supercharger DE-Braak, 53.6178758, 10.239352
 Supercharger-V3 DE-Burgdorf, 52.122814, 10.228904
 Supercharger DE-Busdorf, 54.477896, 9.544913								   
 Supercharger DE-Brinkum, 53.028326, 8.808758
@@ -192,7 +188,6 @@ Supercharger DE-Ellwangen, 48.955835, 10.182623, 55
 Supercharger DE-Emsbüren, 52.359338, 7.26476
 Supercharger-V3 DE-Endsee, 49.445217, 10.246967, 20
 Supercharger-V3 DE-Erfstadt, 50.796478, 6.77994
-Supercharger DE-Erfstadt, 50.796478, 6.77994
 Supercharger-V3 DE-Erlangen, 49.5440686, 11.02870
 Supercharger-V3 DE-Erharting, 48.282664, 12.554758
 Supercharger-V3 DE-Eschborn, 50.133770, 8.561050
@@ -204,7 +199,6 @@ Supercharger-V3 DE-Geiselwind, 49.769526,10.470298, 50
 Supercharger-V3 DE-Geiselwind, 49.769742,10.470259, 50
 Supercharger-V3 DE-Gelnhausen,50.188644,9.186141
 Supercharger-V3 DE-Gensingen, 49.90202, 7.929759
-Supercharger DE-Gensingen, 49.90202, 7.929759
 Supercharger DE-Gramschatzer Wald, 49.91202, 10.00176, 30
 Supercharger-V3 DE-Gramschatzer Wald, 49.912304,10.000582, 30
 Supercharger-V3 DE-Greding,49.041979,11.342705,20
@@ -257,7 +251,6 @@ Supercharger-V3 DE-Knetzgau, 49.982399, 10.555616
 Supercharger-V4 DE-Köln Carlswerk, 50.966078, 7.014042
 Supercharger-V3 DE-Kösching, 48.811333, 11.479899
 Supercharger-V3 DE-Lauenau, 52.279023, 9.35083
-Supercharger DE-Lauenau, 52.279023, 9.35083
 Supercharger-V3 DE-Leer, 53.25967, 7.45557, 25
 Supercharger-V3 DE-Lehre, 52.313216,10.635089
 Supercharger-V3 DE-Leipzig-Flughafen,51.401534,12.181377
@@ -268,7 +261,6 @@ Supercharger-V3 DE-Lippetal, 51.69554, 7.967128
 Supercharger-V3 DE-Linstow, 53.618217, 12.372581
 Supercharger-V3 DE-Lohfelden, 51.271874, 9.5246443
 Supercharger-V3 DE-Lohne, 52.65768, 8.16927
-Supercharger DE-Lohne, 52.65768, 8.16927
 Supercharger DE-Lutterberg alt, 51.370977, 9.633306, 10
 Supercharger DE-Lutterberg, 51.370193,9.633918, 20
 Supercharger DE-Malsfeld, 51.0872578, 9.485137, 20
@@ -279,10 +271,8 @@ Supercharger-V3 DE-Montabaur,50.443591,7.830885,20
 Supercharger DE-Motten, 50.355621, 9.75384
 Supercharger-V3 DE-Murr, 48.956119,9.245459
 Supercharger DE-Mücke, 50.645442, 8.989816
-Supercharger-V3 DE-Mücke, 50.645442, 8.989816
 Supercharger DE-Mühldorf, 48.27257, 12.54995
 Supercharger-V3 DE-Münchberg-Nord, 50.202822,11.776624, 18
-Supercharger DE-Münchberg-Nord, 50.202822,11.776624, 18
 Supercharger-V3 DE-München - Pasing Arcaden, 48.147909,11.464882
 Supercharger-V3 DE-München - OEZ, 48.184493713, 11.5323986
 Supercharger DE-Nempitz, 51.290154,12.137387, 4
@@ -295,7 +285,6 @@ Supercharger DE-Nürburgring, 50.335528, 6.948887
 Supercharger-V3 DE-Nürburgring Motorsport Hotel, 50.33125646, 6.94542238
 Supercharger-V3 DE-Nossen, 51.08255, 13.27406,30
 Supercharger-V3 DE-Norden, 53.61365, 7.16718, 37
-Supercharger DE-Nossen, 51.08255, 13.27406,30
 Supercharger-V3 DE-Northeim, 51.731815, 9.972845
 Supercharger-V3 DE-Nörten-Hardenberg, 51.632847, 9.909942
 Supercharger-V3 DE-Nottuln, 51.911333, 7.398475, 16
@@ -329,14 +318,12 @@ Supercharger-V3 DE-Rosenheim,47.817007,12.120582
 Supercharger-V3 DE-Rüsselsheim,49.968408, 8.390534
 Supercharger DE-Sangerhausen, 51.450551, 11.3044818
 Supercharger-V3 DE-Satteldorf, 49.18119, 10.06933
-Supercharger DE-Satteldorf, 49.18119, 10.06933
 Supercharger-V3 DE-Schönefeld, 52.38872295907895, 13.498046804438706, 30
 Supercharger-V3 DE-Schierling, 48.83825495249082, 12.119170804848606, 30
 Supercharger-V3 DE-Schleiz,50.54638104111437,11.803507002785663,20
 Supercharger-V3 DE-Schleiz,50.54647989730031,11.803035300128926,20
 Supercharger DE-Schweitenkirchen, 48.510765, 11.582025, 19
 Supercharger-V3 DE-Sindelsdorf, 47.728372, 11.361923
-Supercharger DE-Sindelsdorf, 47.728372, 11.361923
 Supercharger-V3 DE-Solingen, 51.129579, 6.995592
 Supercharger-V3 DE-Soltau-Ost,52.983332,9.925548
 Supercharger DE-Stuhr (Bremen-Brinkum), 53.0284305, 8.8061246
@@ -361,9 +348,6 @@ Supercharger-V3 DE-Weiterstadt, 49.89679,8.614198
 Supercharger-V3 DE-Wernberg-Köblitz, 49.532249, 12.134949, 8
 Supercharger-V3 DE-Wernberg-Köblitz, 49.53225, 12.1351, 7
 Supercharger-V3 DE-Wernberg-Köblitz, 49.532255,12.135223, 7
-Supercharger DE-Wernberg-Köblitz, 49.532249, 12.134949, 8
-Supercharger DE-Wernberg-Köblitz, 49.53225, 12.1351, 7
-Supercharger DE-Wernberg-Köblitz, 49.532255,12.135223, 7
 Supercharger DE-Wertheim, 49.770559, 9.576456
 Supercharger-V3 DE-Wertheim-Almosenberg,49.772295,9.587571
 Supercharger-V3 DE-Wetzlar, 50.552762, 8.532845, 30
@@ -372,7 +356,6 @@ Supercharger DE-Wiesbaden, 50.0598477, 8.3451326
 Supercharger DE-Wilnsdorf, 50.8168944, 8.085813
 Supercharger-V3 DE-Wismar, 53.879307, 11.454047
 Supercharger-V3 DE-Wittenburg, 53.507361, 11.096852
-Supercharger DE-Wittenburg, 53.507361, 11.096852
 Supercharger DE-Wittlich, 49.97003, 6.86175
 Supercharger-V3 DE-Woringen, 47.923272, 10.209062
 Supercharger-V3 DE-Wörrstadt,49.839903,8.143498
@@ -450,7 +433,6 @@ Supercharger FI-Äänekoski, 62.516741, 25.6913
 Supercharger FI-Akaa, 61.181106, 23.885075
 Supercharger-V3 FI-Hartola, 61.578409,26.009758
 Supercharger FI-Huittinen, 61.168436, 22.680099
-Supercharger-V3 FI-Huittinen, 61.168436, 22.680099
 Supercharger FI-Jalasjärvi,62.417071,22.791815
 Supercharger-V3 FI-Karesuvanto, 68.450226,22.4814
 Supercharger-V3 FI-Kempele, 64.9018031, 25.5353976
@@ -505,11 +487,9 @@ Supercharger FR-Cagnes-sur-Mer, 43.666446, 7.127372
 Supercharger FR-Châlons-en-Champagne, 48.991982, 4.245320
 Supercharger-V3 FR-Chalon-sur-Saône, 46.796267, 4.835472
 Supercharger FR-Chambéry, 45.593128,5.898171
-Supercharger FR-Chambéry Barberaz, 45.56085, 5.949646
 Supercharger FR-Chapelle sur Erdre, 47.2827707, -1.5500076
 Supercharger FR-Charleville-Mézières, 49.736834, 4.744095
 Supercharger FR-Chasseneuil-du-Poitou, 46.650703, 0.374772
-Supercharger FR-Chemaudin et Vaux,47.234539, 5.901153
 Supercharger FR-Châteauroux, 46.863047, 1.716028
 Supercharger FR-Clermont-Ferrand, 45.785937, 3.141488
 Supercharger FR-Coings, 46.863058, 1.716048
@@ -520,7 +500,6 @@ Supercharger-V3 FR-Dijon, 47.271754, 5.043424
 Supercharger FR-Dommartin-lès-Cuiseaux, 46.496179, 5.310394
 Supercharger FR-Eurotunnel Flexiplus Lounge, 50.929973, 1.813182
 Supercharger FR-Fontainebleau, 48.3495627, 2.6067816
-Supercharger FR-Grenoble, 45.265676, 5.876448
 Supercharger FR-La Léchère-les-Bains, 45.51877, 6.482522
 Supercharger FR-Le Mans, 48.041833, 0.175342
 Supercharger FR-La Seyne-sur-Mer, 43.121199, 5.85086
@@ -551,7 +530,6 @@ Supercharger-V3 FR-Nîmes - Carré Sud, 43.807991, 4.363603, 40
 Supercharger-V3 FR-Nice,43.727727,7.186527
 Supercharger-V3 FR-Niort,46.29825,-0.375256
 Supercharger-V3 FR-Orange, 44.1121375, 4.8517996
-Supercharger FR-Orange, 44.1121375, 4.8517996
 Supercharger FR-Orgeval, 48.925026, 1.996508
 Supercharger FR-Ostwald, 48.534041, 7.702054
 Supercharger FR-Orleans, 47.9488696, 1.868313
@@ -576,14 +554,12 @@ Supercharger-V3 FR-Sisteron,44.22584,5.912426,30
 Supercharger FR-Sisteron,44.225891,5.913562,10
 Supercharger FR-Strasbourg, 48.53407, 7.70201
 Supercharger FR-Thiais,48.754759,2.373078
-Supercharger FR-Toulon, 43.121199, 5.85086
 Supercharger FR-Toulouse, 43.769238, 1.361623
 Supercharger-V3 FR-Tournus, 46.577333, 4.899973, 55
 Supercharger FR-Tours, 47.406937,0.742856
 Supercharger FR-Troyes - Saint-Parres-aux-Tertres, 48.293229, 4.130685
 Supercharger FR-Val-de-Meuse, 47.99147, 5.51296
 Supercharger FR-Valence, 44.91894, 4.878101
-Supercharger FR-Valenciennes, 50.336704, 3.455931
 Supercharger FR-Vienne, 45.58748, 4.78751
 Supercharger GB-Abington, 55.507944, -3.694786
 Supercharger-V3 GB-Amesbury, 51.177215, -1.756282
@@ -676,7 +652,6 @@ Supercharger-V3 IS-Staðarskáli, 65.14475,-21.084813
 Supercharger-V3 IS-Vatnagardar, 64.14496,-21.854711
 Supercharger-V3 IT-Adda Sud,45.510724,9.63624
 Supercharger IT-Affi, 45.551296, 10.787143
-Supercharger-V3 IT-Affi, 45.551296, 10.787143
 Supercharger-V3 IT-Afragola - Napoli North, 40.93333064, 14.35741834
 Supercharger IT-Aosta, 45.73745, 7.371416
 Supercharger-V3 IT-Arese, 45.561371, 9.055905
@@ -723,7 +698,6 @@ Supercharger-V3 IT-Olbia,40.906900,9.515961
 Supercharger IT-Oristano,39.890044,8.599804
 Supercharger-V3 IT-Palermo - Palermo East, 38.08913105, 13.41034177
 Supercharger-V3 IT-Palmanova, 45.88421, 13.34502
-Supercharger IT-Palmanova, 45.88421, 13.34502
 Supercharger IT-Palmi, 38.366929, 15.869555
 Supercharger-V3 IT-Parma North, 44.821080, 10.336591
 Supercharger-V3 IT-Perugia South, 43.047725, 12.40817
@@ -873,7 +847,6 @@ Supercharger-V3 NO-Skien,59.206742,9.6090613
 Supercharger NO-Skjåk, 61.88317, 8.267157
 Supercharger NO-Skulestadmo, 60.658297, 6.436256
 Supercharger NO-Svolvær, 68.233132, 14.559828
-Supercharger NO-Solli, 59.324292, 10.954448
 Supercharger NO-Stjørdal, 63.466385, 10.918098
 Supercharger-V3 NO-Stryn, 61.904677,6.7258
 Supercharger NO-Storjord, 66.814045, 15.401738
@@ -950,7 +923,6 @@ Supercharger-V3 SE-Mantorp, 58.3656796, 15.2939591, 30
 Supercharger-V3 SE-Mariestad,58.677066,13.815005
 Supercharger-V3 SE-Markaryd, 56.444825, 13.603916
 Supercharger-V3 SE-Halmstad, 56.657389, 12.907444
-Supercharger SE-Markaryd, 56.444825, 13.603916
 Supercharger SE-Mellbystrand, 56.501606,12.95763
 Supercharger SE-Mora, 61.005921, 14.54418
 Supercharger-V3 SE-Nacka, 59.3112373, 18.1760186
@@ -962,7 +934,6 @@ Supercharger-V3 SE-Sälen, 61.163666, 13.203015
 Supercharger SE-Skellefteå, 64.76235, 21.002864
 Supercharger SE-Slagelse, 55.388, 11.3622
 Supercharger-V3 SE-Sollentuna, 59.496586,17.92444
-Supercharger SE-Sollentuna, 59.496586,17.92444
 Supercharger-V3 SE-Söderhamn, 61.294919, 17.0209945
 Supercharger SE-Stockholm, 59.5006239, 17.926818
 Supercharger SE-Storlien, 63.310045,12.109286
@@ -1310,7 +1281,6 @@ Tesla Service Center CH-Möhlin, 47.57728, 7.841
 Tesla Service Center CH-Schlieren, 47.40106, 8.4399
 Tesla Service Center CH-Winterthur, 47.49629, 8.6981
 Tesla Service Center DE-Berlin, 52.394091, 13.542292
-Tesla Service Center DE-Berlin,52.392784,13.541575
 Tesla Service Center DE-Düsseldorf, 51.1643, 6.8528
 Tesla Service Center DE-Duisburg,51.476498,6.794394
 Tesla Service Center DE-Feldkirchen, 48.145579, 11.741758
@@ -1398,7 +1368,6 @@ Aldi DE-Friedberg, 48.406611, 10.951264, 10
 Aldi DE-Fußgönheim Am Weisenheimer Weg , 49.467667, 8.286278
 Aldi DE-Fürth Karolinenstraße, 49.467472, 10.995139
 Aldi DE-Fürth Magazinstraße 61, 49.454155, 11.001397, 10
-Aldi DE-Fürth, 49.454280, 11.001354, 10
 Aldi DE-Griesheim Flughafenstraße, 49.860556, 8.590778
 Aldi DE-Heidelberg Im Schuhmachergewann, 49.426194, 8.639611
 Aldi DE-Heidelberg Pleikartsförster Straße, 49.378139, 8.664111
@@ -1608,7 +1577,6 @@ Allego DE-Dettelbach Mainfranken Park 21 , 49.778237284734, 10.069158310707
 Allego DE-Dorf Mecklenburg OT Karow Akazienstraße 1 , 53.852273, 11.457002
 Allego DE-Dorsten Gahlener Str. 306 , 51.657783, 6.904045
 Allego DE-Dortmund An der Buschmühle 1 , 51.494490967762, 7.469635481685
-Allego DE-Dortmund An der Buschmühle 1 , 51.49488, 7.4697688027954
 Allego DE-Dortmund An der Buschmühle 1 , 51.49488, 7.47977
 Allego DE-Dresden ATU, 51.079151, 13.691018
 Allego DE-Dresden Hansastraße 72 , 51.083726795832, 13.739484331772
@@ -1667,7 +1635,6 @@ Allego DE-Essen Grieperstraße 1 , 51.461767, 6.973761
 Allego DE-Essen Grugahalle, 51.431229, 6.999253, 15
 Allego DE-Essen Güterstraße 18 , 51.361183, 6.947746
 Allego DE-Essen Haedenkampstraße 18 , 51.457686, 6.98323
-Allego DE-Essen Hauptbahnhof, 51.452362, 7.013726, 20
 Allego DE-Essen Heidhauser Straße 142 , 51.381933, 7.022
 Allego DE-Essen Heidhauser Straße 257 , 51.374814, 7.015815
 Allego DE-Essen Heinrich-Brauns-Straße 2 , 51.472718, 6.948171
@@ -1712,13 +1679,11 @@ Allego DE-Frankfurt am Main S Tor 32 , 50.026364610596, 8.5872605633545
 Allego DE-Frankfurt am Main Thea-Rasche-Straße , 50.055276, 8.587357
 Allego DE-Freiberg Häuersteig 10 a , 50.895337, 13.330942
 Allego DE-Freiburg Schopfheimer Str. 15 , 47.981077, 7.820611
-Allego DE-Freudenberg Bühler Höhe 2 , 50.912756, 7.910075
 Allego DE-Friedrichshafen Meistershofener Str. 14 , 47.664067, 9.482701
 Allego DE-Fürstenfeldbruck  Zadarstr. 8 , 48.177949, 11.227043
 Allego DE-Fürstenwalde Ehrenfried-Jopp-Str. 16 , 52.366186015625, 14.066417
 Allego DE-Füssen Kemptener Str. 71 , 47.56801, 10.680532
 Allego DE-Garten von Ehren, 53.430268, 9.935228
-Allego DE-Gateway-Gardens Frankfurt, 50.055232, 8.587298, 20
 Allego DE-Gelnhausen Lützelhäuser Weg 13 , 50.188206, 9.185957
 Allego DE-Gelsenkirchen Cranger Straße 160 , 51.569111, 7.079642
 Allego DE-Gera Bieblach, 50.8979565, 12.1008494
@@ -1775,7 +1740,6 @@ Allego DE-Herzsprung,53.067101,12.533024,4
 Allego DE-Heßdorf,49.6272,10.922888,10
 Allego DE-Hildesheim Bavenstedter Str. 71 , 52.164928, 9.97228
 Allego DE-Hilpoltstein, 49.161056, 11.260274, 7
-Allego DE-Hilpoltstein, 49.161067,11.260181, 8
 Allego DE-Hilter Bielefelder Straße 35z , 52.13442, 8.150307
 Allego DE-Himmelkron Bayreuther Straße 3 , 50.056110596753, 11.609460900222
 Allego DE-Himmelkron Kulmbacher Straße 5 , 50.054078, 11.616755
@@ -1848,9 +1812,7 @@ Allego DE-Mücke Gottesrain 2 , 50.645507559587, 8.9901355953655
 Allego DE-Mülheim/Ruhr  Weseler Str. 77 , 51.433012, 6.843968
 Allego DE-Münchberg, 50.20277, 11.77692, 4
 Allego DE-München Bodenseestraße 209 , 48.143433, 11.429782
-Allego DE-Münster ATU, 51.92794, 7.587932
 Allego DE-Neuberg (Erlensee) Röntgenstraße 1, 50.182562, 9.006933
-Allego DE-Neumarkt Autohof, 49.312989, 11.475396, 5
 Allego DE-Neuruppin Wilhelm-Bartelt-Strasse  3 , 52.888557, 12.810769
 Allego DE-Nienburg/Weser Im Meerbachbogen 2 , 52.638019, 9.220892
 Allego DE-Nossen Im Industriegebiet 1 , 51.082719, 13.274013
@@ -1889,7 +1851,6 @@ Allego DE-Rostock Euromaster, 54.111209, 12.16426
 Allego DE-Rostock Goerdelerstraße 52 , 54.099579, 12.072991
 Allego DE-Rostock Hagebaumarkt, 54.099039, 12.176245
 Allego DE-Rostock Handwerkstraße 1a , 54.124824, 12.074337
-Allego DE-Rostock Hinrichsdorfer Str. 7D , 54.111218, 12.164292
 Allego DE-Rostock Zum Südtor 6 , 54.13767, 12.114583
 Allego DE-Rühden, 51.947264, 10.140737, 3
 Allego DE-Saarbruecken Neumuehler Weg 83 , 49.205513, 7.020785
@@ -1903,7 +1864,6 @@ Allego DE-Schoeneiche bei Berlin Kalkberger Str. 189 , 52.472636, 13.738215
 Allego DE-Schorfheide An der B167 6 , 52.849737, 13.68662
 Allego DE-Schweinfurt Friedrich-Rätzer-Str. 3 , 50.027888, 10.237882
 Allego DE-Schweitenkirchen, 48.510717, 11.582345, 3
-Allego DE-Seesen Am Zainer Berg 2 , 51.947263, 10.140783
 Allego DE-Seevetal, 53.396642, 10.042457
 Allego DE-Selbitz Stegenwaldhauser Str. 1 , 50.32453275, 11.785000921875
 Allego DE-Sereetz Sereetzer Feld 1 , 53.926944, 10.722568
@@ -1942,7 +1902,6 @@ Allego DE-Wilhelmshaven Posener Straße 36-38 , 53.574008, 8.094087
 Allego DE-Windischeschenbach Am Gewerbepark  2A , 49.804537, 12.184248
 Allego DE-Winsen Osttangente 210 , 53.350665, 10.223448
 Allego DE-Wismar Kapitänspromenade 29-31 , 53.881171, 11.439219
-Allego DE-Wittstock/Dosse Jägerstraße 1 , 53.067164497463, 12.532995415919
 Allego DE-Wolfhagen Otto-Hahn-Str. 8 , 51.402576330719, 9.1868493937256
 Allego DE-Wolfsburg Braunschweiger Str. 204 , 52.401327, 10.752018
 Allego DE-Wolfsburg Westerlinge 8 , 52.423773, 10.732233
@@ -2402,7 +2361,6 @@ Citywatt DE-Bad Dürrheim Schwenninger Straße 20, 48.032284373167, 8.5323271422
 Citywatt DE-Bad Kissingen Theresienstraße 12, 50.199809985123, 10.073962174123
 Citywatt DE-Bad Klosterlausnitz An der Krümme 3, 50.908396100378, 11.860494507799
 Citywatt DE-Bad Kötzting Weißenregener Straße 1 - 5, 49.169119631094, 12.857079868307
-Citywatt DE-Bad Kötzting Weißenregener Straße 1 - 5, 49.16931, 12.857721
 Citywatt DE-Bad Wörishofen Eichwaldstraße 10, 48.008998, 10.591253
 Citywatt DE-Bad Zwischenahn Langenhof 14, 53.181897, 8.001886
 Citywatt DE-Baden Baden Bahnhofstraße 61, 48.811594, 8.213815
@@ -2491,7 +2449,6 @@ Citywatt DE-Ruderting Gewerbering 4, 48.651902376293, 13.426883728052
 Citywatt DE-Ruderting Haselbacherstraße 8, 48.652921422852, 13.406110763672
 Citywatt DE-Ruderting Passauer Str. 36, 48.649608534464, 13.410787625
 Citywatt DE-Ruderting Passauer Straße 25, 48.652606, 13.410353
-Citywatt DE-Ruderting Passauer Straße 36, 48.64948426794, 13.410241651361
 Citywatt DE-Rödental Nikolaus-August-Otto-Straße 4 Dehner, 50.289074, 11.018452
 Citywatt DE-Salzweg Ebenäcker 2a, 48.6297516875, 13.472371
 Citywatt DE-Salzweg Waldstraße 53, 48.605680199999, 13.485986999984
@@ -2563,7 +2520,6 @@ Comfortcharge DE-Bonn Bonner Talweg, 50.72208, 7.1025
 Comfortcharge DE-Bonn Friedrich-Ebert-Allee, 50.70777, 7.12874
 Comfortcharge DE-Bonn Friesdorfer Straße, 50.691959395747, 7.13684
 Comfortcharge DE-Bonn Landgrabenweg, 50.72395, 7.14534
-Comfortcharge DE-Bonn, 50.708151, 7.128949
 Comfortcharge DE-Bremen Fernmeldeturm, 53.095621, 8.791384
 Comfortcharge DE-Bremen Hohle Straße, 53.173716, 8.629969
 Comfortcharge DE-Bremen Züricher Str, 53.06699, 8.94198
@@ -2987,7 +2943,6 @@ E.ON DE-Bensheim An der A , 49.690307, 8.603811
 E.ON DE-Berg An der A9 , 50.404114602182, 11.772887405499
 E.ON DE-Berg An der A95 , 47.926902, 11.402966
 E.ON DE-Bergen (Chiemgau) An der A8 , 47.827878, 12.590899
-E.ON DE-Bergen (Chiemgau) An der A8 , 47.828935, 12.590243
 E.ON DE-Berlin Alte Jakobstraße 76 , 52.510025, 13.407956
 E.ON DE-Berlin Am Juliusturm 106 , 52.540134, 13.204693
 E.ON DE-Berlin Behrenstraße 28 , 52.515659, 13.389829
@@ -3097,7 +3052,6 @@ E.ON DE-Neufahrn bei Freising An der A9 , 48.337413441773, 11.608161458436
 E.ON DE-Neumünster Polizei, 54.07617, 9.96679
 E.ON DE-Ober-Mörlen An der A5 , 50.356504, 8.695419
 E.ON DE-Oelsnitz/Vogtland An der A72 , 50.433637, 12.130535
-E.ON DE-Pegnitz An der A9 , 49.748483, 11.514098
 E.ON DE-Pfalzfeld, 50.115373, 7.598476
 E.ON DE-Plauen An der A72 , 50.466056, 12.184668
 E.ON DE-Pohlheim An der A5 , 50.52085, 8.7555
@@ -3398,7 +3352,6 @@ EnBW DE-Bad Waldsee Robert-Koch-Str., 47.925554, 9.759089
 EnBW DE-Bad Wurzach Kirchbühlstr., 47.910259, 9.900196
 EnBW DE-Bad Wurzach, 47.907649, 9.897857
 EnBW DE-Bad Wörishofen Türkheimer Straße, 48.01015555, 10.599141666
-EnBW DE-Bad Wörishofen, 48.010187, 10.599257
 EnBW DE-Bad toom, 47.55382166, 7.93050333
 EnBW DE-Baesweiler, 50.919061, 6.1750436
 EnBW DE-Bahlingen Bahnhofstr., 48.125045, 7.741477
@@ -3441,7 +3394,6 @@ EnBW DE-Berlin Rennbahnstr. Hellweg, 52.562119, 13.457348
 EnBW DE-Berlin Rhinstr. Hellweg, 52.544327, 13.510067
 EnBW DE-Berlin Ring-Center, 52.513863, 13.476474
 EnBW DE-Berlin Trebbiner Str., 52.498213, 13.376017
-EnBW DE-Berlin-Biesdorf Hellweg, 52.506824, 13.56589
 EnBW DE-Berlin-Kurfürstendamm Bauhaus, 52.49452, 13.29049
 EnBW DE-Berlin-Köpenick Hellweg, 52.45221, 13.59221
 EnBW DE-Berlin-Köpenick Kaufland, 52.45221, 13.58673
@@ -3467,7 +3419,6 @@ EnBW DE-Bielefeld Burger King, 52.001738, 8.569762
 EnBW DE-Bielefeld Detmolder Straße, 51.996108,8.59518
 EnBW DE-Bielefeld Eckendorfer Str. Burger King, 52.032901, 8.553437
 EnBW DE-Bielefeld Hansestr., 51.951030315945, 8.5726038701275
-EnBW DE-Bielefeld Shell, 51.996258, 8.594841
 EnBW DE-Bienenbüttel, 53.14138, 10.49334
 EnBW DE-Bietigheim Malscher Str., 48.911339, 8.251018
 EnBW DE-Bietigheim Rastatter Str., 48.909522, 8.252883
@@ -3481,10 +3432,8 @@ EnBW DE-Bissingen Schulstraße, 48.6020311, 9.4900528
 EnBW DE-Bissingen Vordere Straße, 48.59938, 9.4914272
 EnBW DE-Bitterfeld, 51.636289,12.19907
 EnBW DE-Bitterfeld-Wolfen Anhaltstr., 51.63867, 12.30895
-EnBW DE-Bitterfeld-Wolfen Burger King, 51.636339, 12.198641
 EnBW DE-Blaustein Boschstr., 48.416998, 9.918955
 EnBW DE-Bobingen Königsbrunner Straße, 48.26401, 10.840595
-EnBW DE-Bobingen, 48.263993, 10.840595, 20
 EnBW DE-Bocholt Hagebaumarkt, 51.83766, 6.595099
 EnBW DE-Bocholt Hellweg, 51.82303, 6.61344
 EnBW DE-Bochum A40,51.476198,7.153262
@@ -3505,14 +3454,11 @@ EnBW DE-Brandenburg an der Havel, 52.430611, 12.550501
 EnBW DE-Brandis, 51.32936, 12.58768
 EnBW DE-Braunsbach Marktplatz, 49.199483, 9.792348
 EnBW DE-Braunschweig Bauhaus, 52.215153059702, 10.530135736267
-EnBW DE-Braunschweig Hildesheimer Str. Bauhaus, 52.271380554369, 10.497192584704
 EnBW DE-Breitengüßbach, 49.973346, 10.87513
 EnBW DE-Bremen Bauhaus, 53.07245, 8.86271
 EnBW DE-Bremen Burger King, 53.053192, 8.74211
 EnBW DE-Bremen Hemmstr., 53.100479, 8.814605
-EnBW DE-Bremen Kirchhuchtinger Landstraße, 53.05324, 8.742137
 EnBW DE-Bremen Shell, 53.082095047683, 8.8769109174228
-EnBW DE-Bremen-Findorff Shell, 53.100487, 8.814521
 EnBW DE-Bremen-Osterholz Bauhaus, 53.052164125748, 8.9621158240252
 EnBW DE-Bremerhaven, 53.54537, 8.59281
 EnBW DE-Bretten Am Viehmarkt, 49.03597, 8.70304
@@ -3526,8 +3472,6 @@ EnBW DE-Bruchsal West , 49.160990420608, 8.5670357814025
 EnBW DE-Bruckmühl Albert-Mayer-Straße, 47.881901, 11.933148
 EnBW DE-Brunautal Ost, 53.109298, 9.983996
 EnBW DE-Brunnthal Happy Schuh, 48.041564, 11.661467
-EnBW DE-Brunnthal Zusestraße, 48.041306, 11.660927
-EnBW DE-Brunnthal,48.041336,11.660908,10
 EnBW DE-Brunsbüttel, 53.900785, 9.122634
 EnBW DE-Buchen (Odenwald) Eberstadter Straße, 49.52098, 9.328713
 EnBW DE-Buchheim Römerweg, 48.012089, 8.986638
@@ -3604,8 +3548,6 @@ EnBW DE-Dieburg Frankfurter Straße, 49.909245, 8.849164
 EnBW DE-Dielheim Hauptstr., 49.282138, 8.735081
 EnBW DE-Dierdorf, 50.54583, 7.63511
 EnBW DE-Dietenheim Kirchstr., 48.21108, 10.068883
-EnBW DE-Dietmannsried A7 Raststätte Allgäuer Tor Ost, 47.847447000213, 10.282954999287
-EnBW DE-Dietmannsried A7 Raststätte Allgäuer Tor West, 47.84820565625, 10.28081434375
 EnBW DE-Dietmannsried Raiffeisenstraße, 47.8046, 10.30008
 EnBW DE-Dillenburg Hellweg, 50.7655313, 8.2852156
 EnBW DE-Dillenburg Rewe, 50.74239, 8.28225
@@ -3661,7 +3603,6 @@ EnBW DE-Ebersbach an der Fils Fritz-Kauffmann-Straße, 48.714952, 9.523914
 EnBW DE-Ebersbach an der Fils Ortsstraße, 48.70821, 9.55544
 EnBW DE-Ebersbach-Musbach Altshauser, 47.953434, 9.576016
 EnBW DE-Ebersberg Am Forst, 48.096563, 11.961209
-EnBW DE-Ebersberg, 48.096569, 11.961316
 EnBW DE-Eberstadt Backhausgasse, 49.178445, 9.32095
 EnBW DE-Eberswalde, 52.829874608775, 13.830185815442
 EnBW DE-Ebhausen Nagolder Str., 48.584699, 8.676206
@@ -3687,7 +3628,6 @@ EnBW DE-Eisenberg (Pfalz) In den Geldäckern, 49.557312, 8.080851
 EnBW DE-Eisingen Talstraße, 48.9478693, 8.6691308
 EnBW DE-Ellhofen, 49.143621,9.308792
 EnBW DE-Ellwangen (Jagst) Doktor-Adolf-Schneider-Straße, 48.95421, 10.169293
-EnBW DE-Ellwangen (Jagst) Rasthof Ellwanger Berge Ost, 48.984851, 10.196098
 EnBW DE-Elmshorn, 53.74573, 9.66126
 EnBW DE-Elsterwerda, 51.465849, 13.533734
 EnBW DE-Elztal Nord , 50.266915808133, 7.2247688630885
@@ -3718,7 +3658,6 @@ EnBW DE-Erkheim Eidlerholzstraße, 48.026165, 10.328535
 EnBW DE-Erlangen BAB A3 Aurach, 49.58181007976, 10.92684514421
 EnBW DE-Erlangen Hofmannstraße, 49.592873,11.014516, 10
 EnBW DE-Erlangen Karl-May-Straße, 49.581707, 10.930694
-EnBW DE-Erlangen Werner-von-Siemens-Straße, 49.592799, 11.01458
 EnBW DE-Erwitte, 51.60625, 8.33675
 EnBW DE-Eschelbronn Bahnhofstr., 49.320104, 8.868043
 EnBW DE-Eschenbach In den Bühlgärten, 48.657721, 9.673706
@@ -3729,7 +3668,6 @@ EnBW DE-Essen Fillendorfer Str. Hellweg, 51.459045, 7.038228
 EnBW DE-Essen Frankenstr. Hellweg, 51.427651, 7.048283
 EnBW DE-Essen Hellweg, 51.380296, 6.93657
 EnBW DE-Essen Krablerstr. Hellweg, 51.485627946314, 6.9963465493722
-EnBW DE-Essen Krablerstraße, 51.485605, 6.9962673
 EnBW DE-Essen Penny, 51.458878, 6.982148
 EnBW DE-Essingen Margarete-Steiff-Straße, 48.821423, 10.045433
 EnBW DE-Esslingen Bahnhofplatz, 48.739303, 9.299276
@@ -3793,7 +3731,6 @@ EnBW DE-Friesoythe, 53.016216, 7.852262, 20
 EnBW DE-Frittlingen Weiherstr., 48.127357, 8.708149
 EnBW DE-Fronreute Hauptstraße, 47.863688, 9.588344
 EnBW DE-Fronreute Schwommengase, 47.864737, 9.589612
-EnBW DE-Fulda, 50.529408864729, 9.6904626647514
 EnBW DE-Fuldabrück, 51.272833230414, 9.5041947044464
 EnBW DE-Fürholzen Ost , 48.336792, 11.611033
 EnBW DE-Fürstenau, 52.5144, 7.686079
@@ -3807,7 +3744,6 @@ EnBW DE-Gaildorf Schloss-Straße, 49.00231, 9.77109
 EnBW DE-Gammertingen Bahnhof, 48.250595,9.217022
 EnBW DE-Gammertingen Feldhauser Str., 48.242712, 9.31022
 EnBW DE-Gammertingen Norma, 48.246655,9.222877
-EnBW DE-Gammertingen Sigmaringer Straße, 48.246593, 9.22287
 EnBW DE-Ganderkesee Hasbruch Nord, 53.055795222656, 8.5012843694453
 EnBW DE-Ganderkesee Hasbruch Süd, 53.054386, 8.5015597
 EnBW DE-Garbsen, 52.42439, 9.5972
@@ -3829,9 +3765,7 @@ EnBW DE-Georgsmarienhütte Brüsseler Str. Penny, 52.22266, 8.084771
 EnBW DE-Georgsmarienhütte Penny, 52.20307, 8.03237
 EnBW DE-Gera Bauhaus, 50.86827, 12.07705
 EnBW DE-Gera Bieblach, 50.8987583, 12.1001272
-EnBW DE-Gera Elsterdamm 5, 50.8681805, 12.07709
 EnBW DE-Gera Globus, 50.8880999, 12.1374571
-EnBW DE-Gera Kaufland, 50.898804, 12.100139
 EnBW DE-Gerabronn Jahnstr., 49.2499, 9.928
 EnBW DE-Gerlingen Fürsaalstr., 48.803266, 9.067024
 EnBW DE-Gerlingen Hofwiesenstr., 48.803839, 9.063077
@@ -3883,7 +3817,6 @@ EnBW DE-Gärtringen Nufringer Str., 48.625422, 8.923513
 EnBW DE-Göttingen West, 51.494746,9.876191
 EnBW DE-Göttingen tegut, 51.554899, 9.939627
 EnBW DE-Güglingen Stadtgraben, 49.067194, 9.000795
-EnBW DE-Günzburg Spielplatzstraße, 48.433351, 10.293138
 EnBW DE-Güstrow, 53.815456, 12.19278
 EnBW DE-Gütersloh, 51.900867, 8.404334
 EnBW DE-Haag in Oberbayern Gerberstraße, 48.16432, 12.167592
@@ -3925,7 +3858,6 @@ EnBW DE-Hammersbach Langen-Bergheim West, 50.248440,8.99398, 10
 EnBW DE-Hannover Am Leineufer, 52.414635, 9.643332, 20
 EnBW DE-Hannover Bauhaus, 52.40991051, 9.70736833
 EnBW DE-Hannover Rewe, 52.338827, 9.832514
-EnBW DE-Hannover Shell, 52.41454, 9.643313
 EnBW DE-Hannover-Wülferode Ost, 52.333124, 9.865546
 EnBW DE-Hannover-Wülferode West, 52.338811, 9.863824
 EnBW DE-Hardegsen, 51.64926, 9.83589
@@ -3948,7 +3880,6 @@ EnBW DE-Heilbronn Etzelstraße, 49.15256, 9.21568
 EnBW DE-Heiligenberg Betenbrunner Str., 47.818553, 9.31358
 EnBW DE-Heiligenroth, 50.454350037681, 7.8729842928874
 EnBW DE-Heiligkreuzsteinach Rathausstr., 49.485795, 8.795633
-EnBW DE-Hellweg Süd,51.593555,8.487382
 EnBW DE-Helmstedt, 52.24045664694, 10.995811098648
 EnBW DE-Hemhofen Peter-Händel-Straße, 49.692286, 10.943354
 EnBW DE-Hennef (Sieg) Bauhaus, 50.77948, 7.27039
@@ -3973,9 +3904,7 @@ EnBW DE-Hettstedt, 51.646759, 11.516185
 EnBW DE-Heusenstamm Werner-von-Siemens-Straße, 50.048875343503, 8.8004937189934
 EnBW DE-Heßdorf, 49.626625,10.923328, 30
 EnBW DE-Hildesheim Albert-Einstein-Str., 52.15948, 9.99422
-EnBW DE-Hildesheim Albert-Einstein-Strasse, 52.15951567929753, 9.994232402647167, 30
 EnBW DE-Hildesheim Prevo, 52.16312, 9.97213
-EnBW DE-Hildesheim Siemensstraße, 52.163101,9.972193
 EnBW DE-Himmelpforten, 53.61389, 9.30104
 EnBW DE-Hirschaid Amlingstadter Straße, 49.828353, 10.989954
 EnBW DE-Hirschaid, 49.819734,11.000681
@@ -4005,7 +3934,6 @@ EnBW DE-Hutthurm Am Kreisel, 48.66868, 13.48394
 EnBW DE-Hutthurm Goldener Steig, 48.666275, 13.48433
 EnBW DE-Höhn, 50.61814, 7.9826
 EnBW DE-Höhr-Grenzhausen Shell, 50.442042, 7.665583
-EnBW DE-Höhr-Grenzhausen, 50.439177,7.647429
 EnBW DE-Hückelhoven, 51.052377, 6.218845
 EnBW DE-Hüfingen Lindenpark, 47.934041020998, 8.4971374552699
 EnBW DE-Hünxe Ost, 51.636934, 6.746968
@@ -4014,11 +3942,9 @@ EnBW DE-Hürth, 50.88546, 6.89686
 EnBW DE-Hüttenberg, 50.521851844128, 8.5901397099196
 EnBW DE-Igersheim, 49.486855,9.820828
 EnBW DE-Illertal Ost, 48.124722, 10.112120, 20
-EnBW DE-Illertal West,48.125496,10.10963,20
 EnBW DE-Ilsfeld A81 Raststätte Wunnenstein, 49.044439272883, 9.2618000542973
 EnBW DE-Ilsfeld Porschestraße, 49.057791, 9.267089
 EnBW DE-Ilshofen Am Feuersee, 49.168867, 9.917508
-EnBW DE-Im Hegau West, 47.861344, 8.786230, 25
 EnBW DE-Immenstaad am Bodensee, 47.66649133, 9.3666571
 EnBW DE-Ingelfingen Criesbacher Str., 49.301461, 9.64681
 EnBW DE-Ingolstadt Am Westpark, 48.775178, 11.387312
@@ -4063,7 +3989,6 @@ EnBW DE-Karlsruhe Durlacher Allee, 49.005770664609, 8.4356339388794
 EnBW DE-Karlsruhe Emmy-Noether-Straße, 49.020164, 8.439899
 EnBW DE-Karlsruhe EnBW InnovationsCampus, 49.014469, 8.310857
 EnBW DE-Karlsruhe Englerstr., 49.01062, 8.41097
-EnBW DE-Karlsruhe Fettweisstr., 49.014446, 8.310795
 EnBW DE-Karlsruhe Gottesauer Platz, 49.007221916378, 8.4235031385965
 EnBW DE-Karlsruhe Gottesauer Straße, 49.008169, 8.417276
 EnBW DE-Karlsruhe Gritznerstr., 48.9993, 8.46532
@@ -4083,7 +4008,6 @@ EnBW DE-Karlsruhe Pfizerstr., 49.024221621049, 8.4561134992898
 EnBW DE-Karlsruhe Rintheimer Querallee, 49.021248, 8.431226
 EnBW DE-Karlsruhe Schlachthausstraße, 49.003887, 8.432444
 EnBW DE-Karlsruhe Stephanienstr., 49.01072, 8.3898
-EnBW DE-Karlsruhe Tollhaus, 49.003884, 8.432467, 10
 EnBW DE-Karlsruhe Yorckstr., 49.00932, 8.37387
 EnBW DE-Kassel, 51.341643233704, 9.4793429022096
 EnBW DE-Kastellaun Johann-Sebastian-Bach-Straße, 50.065768, 7.444039
@@ -4092,8 +4016,6 @@ EnBW DE-Katzenfurt Süd, 50.620318, 8.36309, 5
 EnBW DE-Kaufbeuren Apfeltranger Straße, 47.877862466665, 10.614747253209
 EnBW DE-Kavelstorf, 54.011843, 12.200135
 EnBW DE-Kehl Straßburger Straße, 48.576771, 7.816812
-EnBW DE-Kehring Elztal Nord, 50.266953,7.224861, 20
-EnBW DE-Kehring Elztal Süd, 50.26568,7.22722, 20
 EnBW DE-Keltern Durlacher Str., 48.901983, 8.57661
 EnBW DE-Kempten (Allgäu) Bahnhofstraße, 47.717987, 10.31381
 EnBW DE-Kenzingen Oberhausener Str., 48.18982, 7.76591
@@ -4119,8 +4041,6 @@ EnBW DE-Knittlingen Brettener Str., 49.025647, 8.758897
 EnBW DE-Koblenz Autohof Rübenacher Wald, 50.347123, 7.507522
 EnBW DE-Koblenz Bauhaus, 50.382329, 7.573037
 EnBW DE-Koblenz DM, 50.363464, 7.571934
-EnBW DE-Koblenz Otto-Schönhagen-Straße, 50.382329, 7.573037
-EnBW DE-Koblenz Peter-Klöckner-Straße, 50.363464, 7.571934
 EnBW DE-Korntal-Münchingen Martin-Luther-Str., 48.8296, 9.1203
 EnBW DE-Korntal-Münchingen Schwieberdinger Str., 48.84839, 9.12593
 EnBW DE-Korntal-Münchingen Schöckinger Straße, 48.85269, 9.089186
@@ -4164,7 +4084,6 @@ EnBW DE-Landau an der Isar Fichtheimer Feld, 48.65254, 12.705311
 EnBW DE-Landsberg an der Warthe, 50.521481164384, 7.6955956027398
 EnBW DE-Landshut Liebigstraße, 48.549101, 12.148308
 EnBW DE-Landstuhl Torfstraße, 49.4122, 7.5489
-EnBW DE-Langen-Bergheim Ost , 50.250593467072, 8.9944487965012
 EnBW DE-Langenau Benzstraße, 48.49975, 10.13395
 EnBW DE-Langenau Karlstr., 48.500374, 10.117298
 EnBW DE-Langenau Parkplatz, 48.5000571, 10.123939
@@ -4284,7 +4203,6 @@ EnBW DE-Memmingen Woringer Straße, 47.971073749095, 10.184847340797
 EnBW DE-Memmingen, 47.999336, 10.153201, 10
 EnBW DE-Menden (Sauerland), 51.442689, 7.784449
 EnBW DE-Mendig, 50.382223, 7.269511
-EnBW DE-Mending, 50.382236, 7.269514
 EnBW DE-Mengen Auf dem Hof, 48.048903, 9.326849
 EnBW DE-Meppen Burger King, 52.682704, 7.295721
 EnBW DE-Meppen Euronics, 52.68172, 7.28998
@@ -4320,7 +4238,6 @@ EnBW DE-Möglingen Ludwigsburger Str., 48.888058, 9.135368
 EnBW DE-Mölln, 53.622641, 10.682439
 EnBW DE-Mönchengladbach Bauhaus, 51.15465, 6.45001
 EnBW DE-Mönchengladbach Brunnenstraße, 51.184024, 6.440315
-EnBW DE-Mönchengladbach Shell, 51.183933, 6.44039
 EnBW DE-Mönchengladbach toom, 51.196408, 6.455641
 EnBW DE-Mönsheim Friedrichshof, 48.8387, 8.868
 EnBW DE-Mössingen Zeppelinstr., 48.40418, 9.039732
@@ -4358,7 +4275,6 @@ EnBW DE-Neu-Ulm Augsburger Str., 48.40118, 10.022635
 EnBW DE-Neu-Ulm Euronics, 48.388100, 10.035964
 EnBW DE-Neu-Ulm Europastr., 48.387569, 10.03312
 EnBW DE-Neu-Ulm Finninger Str., 48.39193, 10.0219
-EnBW DE-Neu-Ulm Offenhausen, 48.4011969, 10.022689
 EnBW DE-Neubrandenburg, 53.565091, 13.268248
 EnBW DE-Neuenrade, 51.286080594492, 7.8079518452393
 EnBW DE-Neuhausen Gewerbepark, 47.972133, 8.908268
@@ -4445,13 +4361,11 @@ EnBW DE-Pasewalk, 53.51465, 14.0108
 EnBW DE-Peine Penny, 52.31363, 10.22837
 EnBW DE-Peine Wilhelm-Rausch-Str., 52.339914715898, 10.247883629063
 EnBW DE-Penig, 50.92168985262, 12.714608773529
-EnBW DE-Pentling Ammerholz, 48.97292, 12.065341
 EnBW DE-Perl In der Dörrwiese, 49.474518, 6.373224
 EnBW DE-Petersberg, 50.968487, 11.854993
 EnBW DE-Petershagen, 52.37657, 8.95493
 EnBW DE-Pfaffenhofen Rodbachstr., 49.061537, 8.975544
 EnBW DE-Pfaffenhofen an der Ilm Joseph-Fraunhofer-Straße, 48.535749294984, 11.513692216806
-EnBW DE-Pfaffenhofen an der Ilm Joseph-Fraunhofer-Straße, 48.537125, 11.51367
 EnBW DE-Pfalzgrafenweiler Burgstr., 48.52491, 8.563627
 EnBW DE-Pfarrkirchen Südeinfahrt, 48.421381, 12.942528
 EnBW DE-Pfinztal Römerstraße 28, 48.99361, 8.5408
@@ -4462,7 +4376,6 @@ EnBW DE-Pforzheim Rastatter Straße, 48.899758, 8.667277
 EnBW DE-Pfullingen Schloßstraße, 48.465807, 9.221725
 EnBW DE-Pfungstadt Ost, 49.812106,8.579272
 EnBW DE-Pfungstadt West, 49.8124703, 8.5769616
-EnBW DE-Pfälzer Weinstrasse Ost , 49.270411, 8.153943
 EnBW DE-Philippsburg Rheinschanzinsel, 49.2526653, 8.4371768
 EnBW DE-Philippsburg Rote-Tor-Str., 49.235269, 8.454226
 EnBW DE-Piding Lattenbergstraße, 47.7642445, 12.9035826
@@ -4514,7 +4427,6 @@ EnBW DE-Reichenbach im Vogtland, 50.618995786759, 12.270785312362
 EnBW DE-Reichertshofen Logistikring, 48.643398, 11.520259
 EnBW DE-Reilingen Hockenheimer Str., 49.295266, 8.573869
 EnBW DE-Reinfeld (Holstein), 53.8238989, 10.5019212
-EnBW DE-Reinsfeld Hochwald Ost, 49.690638, 6.899393
 EnBW DE-Rellingen, 53.657268, 9.81385
 EnBW DE-Remscheid, 51.180361, 7.252722
 EnBW DE-Renchtal Ost , 48.562869, 7.959164
@@ -4573,7 +4485,6 @@ EnBW DE-Rüdesheim Auf der Lach, 49.9795126, 7.9341848
 EnBW DE-Rüsselsheim am Main Rugbyring, 49.99718, 8.4241166
 EnBW DE-Saaldorf-Surheim Schulstraße, 47.87547, 12.95888
 EnBW DE-Saarbrücken Dudweiler Landstraße, 49.245986, 7.00497
-EnBW DE-Saarbrücken Rasthof Goldene Bremm Nord, 49.209456,6.966372
 EnBW DE-Sachsenheim Ludwigsburger Straße, 48.957405, 9.074516
 EnBW DE-Sachsenheim Siemensstraße, 48.957956089912, 9.0874181721341
 EnBW DE-Salach Eislinger Straße, 48.692779820729, 9.7312302091501
@@ -4633,7 +4544,6 @@ EnBW DE-Schwentinental, 54.28891, 10.2293
 EnBW DE-Schwerin, 53.597307126114, 11.431819002972
 EnBW DE-Schwetzingen Bahnhofanlage, 49.384752, 8.577721
 EnBW DE-Schwetzingen Kolpingstr., 49.38013, 8.574917
-EnBW DE-Schwetzingen Kolpingstraße, 49.3802133, 8.5753633
 EnBW DE-Schwetzingen Mannheimer Straße, 49.39195, 8.564649
 EnBW DE-Schwetzingen Marktplatz, 49.4072519, 8.5528506
 EnBW DE-Schwetzingen Odenwaldring, 49.38138, 8.58869
@@ -4676,7 +4586,6 @@ EnBW DE-Sindelfingen Rößlesmühlestr., 48.710206, 8.996108
 EnBW DE-Sindelfingen Sindelfinger Wald, 48.741321,9.033325
 EnBW DE-Sindelfingen Sommerhofenstr., 48.723429, 9.014175
 EnBW DE-Sindelfingen Vordere Halde, 48.717795, 9.001901
-EnBW DE-Sindelfinger Wald Süd , 48.741558, 9.03324
 EnBW DE-Singen (Hohentwiel) Hochwaldstraße, 47.753742, 8.86314
 EnBW DE-Singen (Hohentwiel) Marie-Curie-Straße, 47.751632, 8.88602
 EnBW DE-Sipplingen In der Breite, 47.797917, 9.090401
@@ -4730,7 +4639,6 @@ EnBW DE-Straubenhardt Pflugweg, 48.846163, 8.526777
 EnBW DE-Straubing Dresdner Str., 48.883019, 12.614794
 EnBW DE-Straubing Landshuter Straße, 48.867521,12.573991
 EnBW DE-Straubing Posener Straße, 48.886296, 12.615835
-EnBW DE-Straubing Ratiborstraße, 48.886335,12.615851
 EnBW DE-Straßberg Mühlstr., 48.171753, 9.09431
 EnBW DE-Stuhr Bremer Str., 53.02917, 8.807916
 EnBW DE-Stuhr Proppstraße, 53.011943, 8.7045393, 10
@@ -4766,7 +4674,6 @@ EnBW DE-Stuttgart Fasanenhofstraße, 48.7101808, 9.1599208
 EnBW DE-Stuttgart Felix-Dahn-Str., 48.749267, 9.17496
 EnBW DE-Stuttgart Felix-Dahn-Straße, 48.7478519, 9.1667299
 EnBW DE-Stuttgart Finanzamt, 48.77407, 9.16913833
-EnBW DE-Stuttgart Finanzamt,48.774217,9.169022,20
 EnBW DE-Stuttgart Forststraße, 48.77702, 9.15456
 EnBW DE-Stuttgart Forum 3 Cafe, 48.776423430599, 9.1733718209932
 EnBW DE-Stuttgart Fresh Byte, 48.770016, 9.175528
@@ -4840,7 +4747,6 @@ EnBW DE-Stuttgart Stuttgarter Str., 48.810541, 9.163867
 EnBW DE-Stuttgart Suttnerstraße, 48.84156, 9.20502
 EnBW DE-Stuttgart Talstraße, 48.787707, 9.219073
 EnBW DE-Stuttgart Theodor-Heuss-Straße, 48.776143, 9.172493
-EnBW DE-Stuttgart Uni, 48.781844883628, 9.1755655119931
 EnBW DE-Stuttgart Universitätsstr., 48.744688808792, 9.106151
 EnBW DE-Stuttgart Unterländer Str., 48.832286, 9.169204
 EnBW DE-Stuttgart Urbanstr., 48.786999, 9.19245
@@ -4852,7 +4758,6 @@ EnBW DE-Stuttgart Wächterstraße, 48.7703, 9.1844
 EnBW DE-Stuttgart Zellerstr., 48.760979, 9.172501
 EnBW DE-Sulz Oberamtstr., 48.38719, 8.628636
 EnBW DE-Söhlde, 52.21295, 10.19395
-EnBW DE-Sömmerda Leubinger Fürstenhügel, 51.188236,11.162758
 EnBW DE-Sömmerda Rewe, 51.150178, 11.114594
 EnBW DE-Süßen Bühlstr., 48.679149, 9.762005
 EnBW DE-Süßen Sommerauweg, 48.67797, 9.765328
@@ -4873,7 +4778,6 @@ EnBW DE-Tuningen Auf dem Platz, 48.026825, 8.601636
 EnBW DE-Tuttlingen BMW, 47.97311, 8.83444
 EnBW DE-Tuttlingen Daimlerstraße, 47.993541, 8.826812
 EnBW DE-Tuttlingen Eltastraße, 47.988175, 8.795767
-EnBW DE-Tuttlingen Eltastraße, 47.989192001923, 8.796585996582
 EnBW DE-Tuttlingen Graf Hardenberg, 47.976135, 8.822173
 EnBW DE-Tuttlingen Graf-Von-Stauffenberg-Platz, 47.99873, 8.81713
 EnBW DE-Tuttlingen Heinrich-Rieker-Str., 47.982607055267, 8.8052368975691
@@ -4894,13 +4798,11 @@ EnBW DE-Ulm Alnatura, 48.4003902, 9.9703137
 EnBW DE-Ulm Blaubeurer Straße, 48.4028, 9.974236
 EnBW DE-Ulm Riedwiesenweg, 48.402758, 9.94634
 EnBW DE-Ulm Seligweiler, 48.456817, 10.029649
-EnBW DE-Ulm, 48.456880, 10.029673, 15
 EnBW DE-Ummendorf Bachstraße, 48.064293, 9.830137
 EnBW DE-Unna, 51.531049, 7.671075
 EnBW DE-Unterföhring Feringastr., 48.179208, 11.633316
 EnBW DE-Untergriesbach Kreuzwiesenweg, 48.576794, 13.666633
 EnBW DE-Unterhaching Grünwalder Weg, 48.056309, 11.60163
-EnBW DE-Unterhaching, 48.056003,11.601168
 EnBW DE-Unterschneidheim Nordhäuser Str., 48.941855, 10.371133
 EnBW DE-Unterstadion Kirchstr., 48.204572, 9.689049
 EnBW DE-Urbach, 48.810151, 9.570358
@@ -4911,7 +4813,6 @@ EnBW DE-Vaihingen an der Enz Franckstr., 48.931382070499, 8.9601788156158
 EnBW DE-Vaihingen an der Enz Hertzstr., 48.926931, 8.966447
 EnBW DE-Vaihingen an der Enz Im Mühlkanal, 48.931392, 8.95571
 EnBW DE-Veitsbronn Fürtherstr., 49.50469, 10.89338
-EnBW DE-Vellern, 51.791005, 8.073981
 EnBW DE-Veringenstadt Im Städtle, 48.178307, 9.212785
 EnBW DE-Viernheim Wiesenstraße, 49.544908, 8.589202
 EnBW DE-Villingen-Schwenningen Auf Herdenen, 48.076799, 8.500723
@@ -4978,13 +4879,11 @@ EnBW DE-Werl Penny, 51.54913, 7.918847
 EnBW DE-Wernau Junkersstr., 48.688394, 9.421421
 EnBW DE-Wernau Kirchheimer Str., 48.690074, 9.419009
 EnBW DE-Wernberg-Köblitz Klaus-Conrad-Straße, 49.531963, 12.137473
-EnBW DE-Werratal-Süd, 51.006899, 10.180782
 EnBW DE-Wertheim Almosenberg., 49.772486, 9.579439
 EnBW DE-Wertheim McDonalds, 49.771187, 9.58819
 EnBW DE-Wesel, 51.65332, 6.60665
 EnBW DE-Wesseling Euronics, 50.8308144, 6.962217
 EnBW DE-Wesseling Shell, 50.811416, 6.99092
-EnBW DE-Westendorf Am Oberfeld, 48.557685706808, 10.852364936594
 EnBW DE-Westerburg, 50.56099, 7.96935
 EnBW DE-Westerstede, 53.263355, 7.9418
 EnBW DE-Westhausen Baiershofener Straße, 48.883286, 10.177844
@@ -4997,7 +4896,6 @@ EnBW DE-Wiesbaden Erich-Ollenhauer-Straße, 50.06148, 8.21726
 EnBW DE-Wiesloch Adelsförsterpfad, 49.2948, 8.667
 EnBW DE-Wiesloch In den Ziegelwiesen, 49.2905, 8.6648
 EnBW DE-Wiesloch Meßplatzstr., 49.293157, 8.701533
-EnBW DE-Wietmarschen, 52.527876, 7.1965148
 EnBW DE-Wietzendorf, 52.944965412447, 9.881728552972
 EnBW DE-Wildau, 52.3179906, 13.605636
 EnBW DE-Wildberg Hohe Gasse, 48.623846, 8.746806
@@ -5046,7 +4944,6 @@ EnBW DE-Zeven, 53.27713, 9.293374
 EnBW DE-Zimmern o.R. Hauptstr., 48.166915, 8.5931225
 EnBW DE-Zirndorf Albert-Einstein-Straße, 49.44567, 10.95122
 EnBW DE-Zwickau Hellweg, 50.753058, 12.481222
-EnBW DE-Zwickau Ost, 50.6804694, 12.5907821, 25
 EnBW DE-Zwickau Rossmann, 50.737925, 12.491723
 EnBW DE-Öhringen Austraße, 49.204334, 9.488376
 EnBW DE-Öhringen Euronics, 49.20321, 9.491336
@@ -5058,7 +4955,6 @@ EVM DE-Cochem Bahnhofsvorplatz, 50.153328, 7.167515
 EVM DE-Koblenz Altstadt, 50.359981, 7.598084
 EVM DE-Koblenz Autohaus Löhr Becker, 50.378368, 7.585333
 EVM DE-Koblenz Autohaus Pretz, 50.334257, 7.6065574
-EVM DE-Koblenz Autohof Rübenacher Wald, 50.346812, 7.507836
 EVM DE-Koblenz Contel Hotel, 50.365908, 7.577220
 EVM DE-Koblenz Festung Ehrenbreitstein, 50.367221, 7.617626
 
@@ -5104,7 +5000,6 @@ EWE-GO DE-Bad Zwischenahn Am Hogen Hagen, 53.182726, 8.0151
 EWE-GO DE-Bad Zwischenahn Feldlinie, 53.17303, 8.06829
 EWE-GO DE-Bad Zwischenahn Hainbuchenweg, 53.16708, 8.15484
 EWE-GO DE-Bad Zwischenahn Heideweg, 53.1666, 8.15593
-EWE-GO DE-Bad Zwischenahn Langenhof, 53.181964, 8.002596
 EWE-GO DE-Bad Zwischenahn Oldenburger Straße, 53.18097, 8.022766
 EWE-GO DE-Bad Zwischenahn Pastor-Schulze-Straße, 53.182879, 7.998432
 EWE-GO DE-Bakum Bahnhofstraße, 52.73934, 8.19203
@@ -5121,10 +5016,8 @@ EWE-GO DE-Barßel Oldenburger Straße, 53.151186, 7.711911
 EWE-GO DE-Barßel Theodor-Klinker-Platz, 53.169091, 7.744814
 EWE-GO DE-Barßel Westmarkstraße, 53.166408, 7.736687
 EWE-GO DE-Bassum Bahnhofstraße, 52.846071, 8.73421
-EWE-GO DE-Bayreuth Sophian-Kolb-Straße, 49.95756, 11.60226
 EWE-GO DE-Bebra Gottlieb-Daimler-Straße, 50.962304, 9.790174
 EWE-GO DE-Bendorf Adolph-Kolping-Straße, 50.42631, 7.57001
-EWE-GO DE-Bensheim Wormser Straße, 49.67255, 8.59743
 EWE-GO DE-Bergisch Gladbach Richard-Zanders-Straße, 50.98502, 7.12195
 EWE-GO DE-Bergkamen Werner Straße, 51.6176, 7.65996
 EWE-GO DE-Berlin Charlottenburger Chaussee, 52.526533, 13.23301
@@ -5349,7 +5242,6 @@ EWE-GO DE-Geestland An der Burg, 53.625548, 8.84232
 EWE-GO DE-Geestland Dorfmitte, 53.676407, 8.68278
 EWE-GO DE-Geestland Handelspark, 53.627408, 8.810123
 EWE-GO DE-Geldern Weseler Straße, 51.52319, 6.34643
-EWE-GO DE-Gelsenkirchen Grothusstr., 51.521639752567, 7.073401732029
 EWE-GO DE-Gelsenkirchen Wickingstraße, 51.50334, 7.10798
 EWE-GO DE-Georgsmarienhütte Klöcknerstraße, 52.206117246094, 8.0587508007813
 EWE-GO DE-Germersheim Mainzer Straße, 49.227211, 8.371534
@@ -5371,7 +5263,6 @@ EWE-GO DE-Göttingen Siekweg, 51.52766, 9.88937
 EWE-GO DE-Hage Baantjebur, 53.601228, 7.282605
 EWE-GO DE-Hagen im Bremischen Am Neumarkt, 53.35953, 8.66188
 EWE-GO DE-Halberstadt Im Sülzeteiche, 51.88032, 11.0769
-EWE-GO DE-Haldensleben Johann-Gottlob-Nathusius-Straße, 52.28045, 11.432315
 EWE-GO DE-Halle (Saale) Rosenfelder Straße, 51.50131, 12.03321
 EWE-GO DE-Halle Magdeburger Chaussee, 51.52261, 11.95361
 EWE-GO DE-Hallstadt Emil-Kemmer-Straße, 49.91796, 10.87311
@@ -5544,7 +5435,6 @@ EWE-GO DE-Löningen Poststraße, 52.734376, 7.759257
 EWE-GO DE-Löningen Ringstraße, 52.742508, 7.759159
 EWE-GO DE-Löningen Tabbenstraße, 52.73443, 7.75663
 EWE-GO DE-Lübbecke Thyssenstraße, 52.32146, 8.62589
-EWE-GO DE-Lübbenau/Spreewald LPG-Straße, 51.84966, 13.90757
 EWE-GO DE-Lübeck Bei der Lohmühle, 53.880904, 10.673955
 EWE-GO DE-Lübeck Hinter den Kirschkaten, 53.848088, 10.677746
 EWE-GO DE-Lüdinghausen Valve, 51.76691, 7.45978
@@ -5559,11 +5449,9 @@ EWE-GO DE-Marktoberdorf Brückenstraße, 47.773399, 10.60495
 EWE-GO DE-Marktredwitz Böttgerstraße, 50.0134, 12.09918
 EWE-GO DE-Martfeld Hauptstraße, 52.876632, 9.062726
 EWE-GO DE-Massen-Niederlausitz Ludwig-Erhard-Straße, 51.63656, 13.73728
-EWE-GO DE-Meerane Hohe Straße, 50.841761, 12.44489
 EWE-GO DE-Meißen Fabrikstraße, 51.164993, 13.489314
 EWE-GO DE-Melle Industriestraße, 52.190412132036, 8.3527933577986
 EWE-GO DE-Menden Hämmerstraße, 51.450727, 7.752865
-EWE-GO DE-Mendig Ludwig-Erhard-Straße, 50.382029, 7.269635
 EWE-GO DE-Mering Hertzstraße, 48.273707, 10.97776
 EWE-GO DE-Mettmann Rudolf-Diesel-Straße, 51.25339, 6.95167
 EWE-GO DE-Minden Lübbecker Straße, 52.278228, 8.902649
@@ -5811,7 +5699,6 @@ EWE-GO DE-Verden Hamburger Straße, 52.94841, 9.233362
 EWE-GO DE-Viersen Freiheitsstraße, 51.25313, 6.39887
 EWE-GO DE-Visbek Corveystraße, 52.835764, 8.311329
 EWE-GO DE-Visbek Rechterfelder Straße, 52.836613, 8.313362
-EWE-GO DE-Visbek Rechterfelder Straße, 52.836678, 8.316098
 EWE-GO DE-Visselhövede Goethestraße, 52.985295, 9.579349
 EWE-GO DE-Visselhövede Süderstraße, 52.983839, 9.580985
 EWE-GO DE-Völklingen Saarwiesenstraße, 49.24488, 6.86337
@@ -5845,7 +5732,6 @@ EWE-GO DE-Werlte Unfriedstraße, 52.850166, 7.658131
 EWE-GO DE-Wermelskirchen Bandwirkerstr., 51.13692, 7.19943
 EWE-GO DE-Werne Nordlippestraße, 51.698298699989, 7.672388
 EWE-GO DE-Wernigerode Dornbergsweg, 51.85254, 10.79018
-EWE-GO DE-Wertheim Almosenberg, 49.77108, 9.58765
 EWE-GO DE-Westerholt Closterstraße, 53.58365, 7.46458
 EWE-GO DE-Westerholt Nordener Straße, 53.58969, 7.457914
 EWE-GO DE-Westerstede Am Hamjebusch, 53.256749, 7.935833
@@ -5861,7 +5747,6 @@ EWE-GO DE-Weyhe Im Bruch, 52.984732, 8.84356
 EWE-GO DE-Wiefelstede Kirchstraße, 53.25615, 8.11495
 EWE-GO DE-Wiesmoor Hauptstraße, 53.400672, 7.712459
 EWE-GO DE-Wiesmoor Kanalstr II, 53.39487, 7.70292
-EWE-GO DE-Wildenfels Arno-Schmidt-Straße, 50.68072, 12.59116
 EWE-GO DE-Wildeshausen Delmenhorster Straße, 52.902774869048, 8.4444769583328
 EWE-GO DE-Wildeshausen Gildeplatz, 52.896432, 8.438846
 EWE-GO DE-Wildeshausen Glaner Straße, 52.90179, 8.416729
@@ -5897,20 +5782,13 @@ EWE-GO DE-Zeitz Geußnitzer Straße, 51.03663, 12.16023
 EWE-GO DE-Zetel Neuenburger Straße, 53.41799, 7.972179
 EWE-GO DE-Zeven Kivinanstraße, 53.292162, 9.274971
 EWE-GO DE-Zwickau Oskar-Arnold-Straße, 50.70627, 12.50094
-EWE-GO DE-Zwickau Ost, 50.6807333, 12.591146, 10
 EWE-GO DE-Zülpich Villa Rustica, 50.704799, 6.669532
 EWE-GO DE-Überlingen Abigstraße, 47.774522, 9.186378
 
-EWE-SWB DE-Bremen P&R Grolland, 53.058181, 8.757356
-EWE-SWB DE-Burgwedel, 52.485739, 9.844603
 EWE-SWB DE-Emden, 53.389098,7.230491, 20
 EWE-SWB DE-Friesoythe, 53.014858, 7.851011
 EWE-SWB DE-Illertissen, 48.219521,10.126724, 10
 EWE-SWB DE-Marktrodach, 50.256351, 11.397455
-EWE-SWB DE-Meerane, 50.8417537, 12.4448933, 5
-EWE-SWB DE-Moormerland, 53.311881, 7.456651
-EWE-SWB DE-Oldenburg Bremer Heerstraße, 53.119092,8.258616
-EWE-SWB DE-Unterschleißheim,48.28377,11.563749,3
 
 Fastned BE-Oostende luchthaven, 51.205610, 2.871165
 Fastned DE-Altmühltal, 48.997562, 11.375364
@@ -5924,7 +5802,6 @@ Fastned DE-Düren Rurbenden, 50.840567, 6.45579
 Fastned DE-Eching,48.306759,11.639883,10
 Fastned DE-Egelsbach Kurt-Schumacher-Ring, 49.962742, 8.673279
 Fastned DE-Frankfurt am Main Eugen-Hartmann-Straße, 50.14704, 8.609
-Fastned DE-Freiwalde, 51.948979, 13.7877
 Fastned DE-Friedberg, 48.407453, 10.952015
 Fastned DE-Fürth Hochstraße, 49.48077, 10.97588
 Fastned DE-Giengen-Herbrechtingen, 48.61561, 10.20539
@@ -5932,11 +5809,8 @@ Fastned DE-Gießen Ferniestraße, 50.57151, 8.68999
 Fastned DE-Gladbeck-Ellinghorst, 51.5552, 6.96951
 Fastned DE-Goldbach, 49.993547,9.173447
 Fastned DE-Herbolzheim, 48.22685, 7.75509
-Fastned DE-Hermsdorf, 50.8897673, 11.8719638, 18
 Fastned DE-Hilden, 51.192201,6.935931,3
-Fastned DE-Hilden, 51.192231,6.93605,3
 Fastned DE-Hildesheim, 52.16083, 9.99676
-Fastned DE-Kinding Am, 48.99753, 11.37529
 Fastned DE-Leutkirch im Allgäu Auf der, 47.83136, 10.00428
 Fastned DE-Limburg Süd, 50.37993, 8.09248
 Fastned DE-Melle-West, 52.19466, 8.31641
@@ -5986,7 +5860,6 @@ Fastned NL-Labbegat, 51.69393, 5.01359
 Fastned NL-Laerd, 53.051399, 5.553802
 Fastned NL-Lemsterhop, 52.818501, 5.742350
 Fastned NL-Lepelaar, 52.432869, 5.422989
-Fastned NL-Lohberg,51.58105,6.763821
 Fastned NL-Mastpolder, 51.547724, 4.530389
 Fastned NL-Molenkamp,  51.84753, 5.19078
 Fastned NL-Ooiendonk, 51.556297, 5.361872
@@ -6091,13 +5964,10 @@ Ionity CZ-Pávov (dir. Brno), 49.453814, 15.591480
 Ionity CZ-Pávov (dir. Prague), 49.455104, 15.593272
 Ionity DE-Aachener Land Nord, 50.817668, 6.213854
 Ionity DE-Aachener Land Süd, 50.817306, 6.216629
-Ionity DE-Aalbek West, 54.092671, 9.92914
 Ionity DE-Altenburger Land Nord, 50.860662, 12.307977
 Ionity DE-Altenburger Land Süd, 50.85675, 12.3132
 Ionity DE-Am Fichtenplan Nord, 52.318183, 13.494709
 Ionity DE-Am Fichtenplan Süd, 52.315620, 13.494702
-Ionity DE-Auetal Nord, 52.223703, 9.221469
-Ionity DE-Auetal Süd, 52.226977, 9.232545
 Ionity DE-Augsburg Ost, 48.411614, 10.914898
 Ionity DE-Bad Camberg West, 50.299926, 8.234700
 Ionity DE-Bad Honnef, 50.647664, 7.334521
@@ -6109,90 +5979,45 @@ Ionity DE-Bochum, 51.474082, 7.151429
 Ionity DE-Brohltal Ost, 50.440471, 7.225629
 Ionity DE-Brohltal West, 50.441534, 7.223985
 Ionity DE-Brokenlande Ost, 54.014217, 9.93325
-Ionity DE-Bruchsal Ost, 49.162694, 8.570788
-Ionity DE-Bruchsal West, 49.16125, 8.567226
 Ionity DE-Buddikate Ost, 53.694396, 10.324738
 Ionity DE-Buddikate West, 53.692558, 10.320428
 Ionity DE-Castrop Rauxel Grutholzallee, 51.566342, 7.317542
 Ionity DE-Dammer Berge Ost, 52.539229, 8.114598
-Ionity DE-Dammer Berge West, 52.540755, 8.112701
-Ionity DE-Demminer Land, 53.855673, 13.333344
-Ionity DE-Denkendorf Hoher Rain, 48.693667, 9.303297
-Ionity DE-Denkendorf Nord, 48.693667, 9.303297
-Ionity DE-Dettelbach Mainfrankenpark, 49.777979, 10.068774
-Ionity DE-Dietingen Autobahn A 81, 48.20593, 8.621045
 Ionity DE-Dietmannsried Glaserstraße, 47.811904, 10.302936
-Ionity DE-Dollenberg Ost, 50.688524, 8.295916, 5
 Ionity DE-Donautal Ost, 48.588065, 13.366667
 Ionity DE-Donautal West, 48.589422, 13.365369
 Ionity DE-Dresdner Tor Nord, 51.063214, 13.571071
-Ionity DE-Dresdner Tor Süd, 51.060227, 13.571959
 Ionity DE-Eching Dieselstraße, 48.310848, 11.646729
-Ionity DE-Eching, 48.3108951, 11.646281
-Ionity DE-Eichenzell, 50.488366, 9.708621, 8
-Ionity DE-Eifel Ost, 50.070186, 6.880905
-Ionity DE-Eifel West, 50.068492, 6.880212
-Ionity DE-Forst A5 Ost, 49.162694, 8.570788
-Ionity DE-Forst A5 West, 49.16125, 8.567226
 Ionity DE-Frankenhöhe Nord, 49.242629, 10.352944
 Ionity DE-Frankenhöhe Süd, 49.241155, 10.356121
 Ionity DE-Garching bei München Parkring, 48.249323, 11.634365
-Ionity DE-Goldbach Nord, 53.000606, 9.179514
-Ionity DE-Goldbach Süd, 52.998531, 9.181213
 Ionity DE-Gruibingen  Autobahn, 48.605321, 9.632807
-Ionity DE-Gruibingen Süd, 48.605321, 9.632807
 Ionity DE-Haidt Nord, 49.780852, 10.244797
 Ionity DE-Haidt Süd, 49.779352, 10.246493
 Ionity DE-Hamminkeln, 51.739103, 6.595180
 Ionity DE-Harz Ost, 51.926279, 10.143238
-Ionity DE-Harz West, 51.928028, 10.141730
-Ionity DE-Hausen bei Würzburg An der BAB A7 West, 49.945695, 10.016764
 Ionity DE-Heiligengrabe Liebenthaler Dorfstraße, 53.147243, 12.398704
 Ionity DE-Hepberg A9 Köschinger Forst, 48.837085, 11.469313
-Ionity DE-Himmelkron, 50.055972, 11.609148
-Ionity DE-Hohenlohe Nord, 49.207007, 9.639273
-Ionity DE-Hohenlohe Süd, 49.205379, 9.639696
-Ionity DE-Hohenwarsleben, 52.173898, 11.49512, 11
 Ionity DE-Holzkirchen Nord, 47.892208, 11.731279
 Ionity DE-Holzkirchen Süd, 47.906573, 11.717379
 Ionity DE-Illertissen, 48.219287,10.127852, 13
 Ionity DE-Kaiserslautern Mainzer Straße, 49.456353, 7.797315
-Ionity DE-Katzenfurt Süd, 50.620347, 8.362918, 5
 Ionity DE-Kirchheim (Tal), 50.833695, 9.5707772, 20
 Ionity DE-Kirchheim Burger King, 50.8332832, 9.5731819
-Ionity DE-Kirchheim Hauptstraße, 50.833347, 9.573252
-Ionity DE-Kirchheim Industriestraße, 50.833837, 9.570775
 Ionity DE-Köschinger Forst Ost, 48.836599, 11.472234
-Ionity DE-Köschinger Forst West, 48.837085, 11.469313
 Ionity DE-Lechwiesen Nord, 48.059266, 10.846791
 Ionity DE-Lechwiesen Süd, 48.058328, 10.847694
-Ionity DE-Lehrter See Nord, 52.388762, 9.99631
-Ionity DE-Lehrter See Süd, 52.386433, 9.998919
 Ionity DE-Leinefelde-Worbis Ernemannstraße, 51.390739, 10.342552
 Ionity DE-Lichtendorf Nord, 51.468319, 7.594014
 Ionity DE-Lichtendorf Süd, 51.467751, 7.596959
 Ionity DE-Linthe Westfalenstraße, 52.160118, 12.779906
 Ionity DE-Lippetal, 51.695845, 7.966201
-Ionity DE-Lonetal Ost, 48.584246, 10.178939, 10
-Ionity DE-Lonetal West, 48.583937, 10.175605, 10
 Ionity DE-Lutterberg, 51.370342, 9.633558, 8
-Ionity DE-Lutterberg, 51.370434,9.63373,8
 Ionity DE-Lüneburger Heide Ost, 53.110044, 9.984058
-Ionity DE-Lüneburger Heide West, 53.109317, 9.981663
-Ionity DE-Mahlberg Ost, 48.308819, 7.791519
-Ionity DE-Mahlberg West, 48.309517, 7.788855
 Ionity DE-Meerane Hohe Straße, 50.840764, 12.445016
 Ionity DE-Merklingen Nellinger Str., 48.516511, 9.756944
 Ionity DE-Mühldorf am Inn Äußere Neumarkter Str, 48.262445, 12.542657
-Ionity DE-Nahetal, 49.92578, 7.936795
-Ionity DE-Neckarburg Ost, 48.206218, 8.627155
-Ionity DE-Neckarburg West, 48.20593, 8.621045
 Ionity DE-Nempitz, 51.290114,12.137547, 6
-Ionity DE-Nempitz, 51.290159,12.1376, 6
-Ionity DE-Neuenstein Lohemerfeld, 49.207007, 9.639273
-Ionity DE-Neumarkt, 49.312948, 11.474745, 20
-Ionity DE-Neumünster Prehnsfelder Weg, 54.092671, 9.92914
-Ionity DE-Niederöfflingen An der BAB A1, 50.068492, 6.880212
 Ionity DE-Oberhausen Brammenring, 51.489778, 6.887922
 Ionity DE-Oberkrämer Im Gewerbepark, 52.709772, 13.107945
 Ionity DE-Oelde In d. Geist, 51.812002, 8.131019
@@ -6206,10 +6031,8 @@ Ionity DE-Pilsting, 48.692530, 12.672979
 Ionity DE-Polch Im Roten Tal, 50.306876, 7.306114
 Ionity DE-Porta Westfalica Zum Autohof, 52.209983, 8.872595
 Ionity DE-Reinhardshain Nord, 50.622937, 8.894846
-Ionity DE-Reinhardshain Süd, 50.622096, 8.897196
 Ionity DE-Remscheid Ost, 51.158407, 7.230332
 Ionity DE-Riedener Wald Ost, 49.944184, 10.019955
-Ionity DE-Riedener Wald West, 49.945693, 10.016739
 Ionity DE-Rostock Timmermannsstrat, 54.083283, 12.19232
 Ionity DE-Salzbergen, 52.326149, 7.430067
 Ionity DE-Samerberg Nord, 47.802835, 12.178503
@@ -6217,23 +6040,16 @@ Ionity DE-Samerberg Süd, 47.801229, 12.177198
 Ionity DE-Sangerhausen, 51.450971, 11.305148
 Ionity DE-Schwabhausen, 50.898384, 10.725625
 Ionity DE-Spessart Nord, 49.898302, 9.394346
-Ionity DE-Staufenberg Triftstraße, 51.370378, 9.633582
 Ionity DE-Thüringer Wald Nord, 50.726454, 10.841634
 Ionity DE-Thüringer Wald Süd, 50.724708, 10.847168
-Ionity DE-Todendorf Buddikate West an der BaB 1, 53.692518, 10.320397
-Ionity DE-Völschow Rastplatz Demminer Land E251, 53.855673, 13.333344
 Ionity DE-Weiskirchen Süd, 50.054708, 8.908177
 Ionity DE-Wernberg-Köblitz, 49.532356, 12.134910, 3
-Ionity DE-Wilsdruff Raststätte Dresdner Tor Süd A4 Richtung Ost, 51.060227, 13.571959
 Ionity DE-Wismar Am Ring, 53.893217, 11.513095
 Ionity DE-Wittlich Straßburgstraße, 49.966871, 6.942735
 Ionity DE-Wolfsburg Allerpark, 52.437710, 10.809069
 Ionity DE-Wolfsburg Braunschweiger Str., 52.416656, 10.783389
 Ionity DE-Wolfsburg Detmeroder Markt, 52.392241, 10.753713
 Ionity DE-Wolfsburg Forum AutoVision, 52.424872, 10.745689
-Ionity DE-Wolfsburg Marignanestraße, 52.392241, 10.753713
-Ionity DE-Wunnenstein Ost, 49.045334, 9.266223
-Ionity DE-Wunnenstein West, 49.044276, 9.261639
 Ionity DK-Aabenraa, 55.065192, 9.366167
 Ionity DK-Fredericia, 55.53682, 9.7169
 Ionity DK-Greve, 55.58492, 12.258
@@ -6429,7 +6245,6 @@ Ionity SE-Spekerød, 58.0244, 11.84746
 Ionity SE-Strømstad, 58.91483, 11.26034
 Ionity SE-Sundsvall, 62.33874, 17.3538
 Ionity SE-Ulricehamn, 57.81289, 13.41947
-Ionity SE-Uppsala, 47.16577, 0.63161
 Ionity SE-Varberg, 57.168, 12.2774
 Ionity SE-Värnamo, 57.1645, 14.07578
 Ionity SE-Ytterån, 63.31709, 14.1692
@@ -6467,12 +6282,10 @@ Innogy DE-Berlin Alt-Mariendorf, 52.440133, 13.387033
 Innogy DE-Berlin Alt-Moabit, 52.523192, 13.362577
 Innogy DE-Berlin Alt-Rudow, 52.41626, 13.496625
 Innogy DE-Berlin Augsburger Str. 25 (ggü. Lang und, 52.501328, 13.335408
-Innogy DE-Berlin Avus, 52.501775, 13.277211
 Innogy DE-Berlin Bahnhofstr., 52.469967, 13.339781
 Innogy DE-Berlin Bayreuther Str., 52.501159, 13.343907
 Innogy DE-Berlin Bellevuestraße, 52.510384, 13.37361
 Innogy DE-Berlin Boyenstr., 52.535977, 13.36889
-Innogy DE-Berlin Brunsbütteler Damm, 52.533676, 13.174356
 Innogy DE-Berlin Charlottenburger Chaussee, 52.528134, 13.2264
 Innogy DE-Berlin Fasanenstr., 52.505042, 13.327423
 Innogy DE-Berlin Frankfurter Allee, 52.511752, 13.497569
@@ -6529,8 +6342,6 @@ Innogy DE-Brühl Renault-Nissan Straße, 50.843295, 6.904076
 Innogy DE-Buch Untere Straße, 48.223334, 10.178266
 Innogy DE-Buchloe Bahnhofstraße, 48.0358, 10.72347
 Innogy DE-Cloerbruch Nord, 51.237662, 6.513529
-Innogy DE-Cloerbruch Süd, 51.236686, 6.510928
-Innogy DE-Dannstadt-Schauernheim, 49.410297, 8.339979
 Innogy DE-Delmenhorst Reinersweg, 53.036667, 8.672222
 Innogy DE-Donauwörth Adolph-Kolping-Straße, 48.71649, 10.77942
 Innogy DE-Dortmund Altwickeder Hellweg, 51.533611, 7.624722
@@ -6560,7 +6371,6 @@ Innogy DE-Dortmund Wenzelstr Ecke, 51.489186, 7.502455
 Innogy DE-Dortmund Werner Straße, 51.499444, 7.333333
 Innogy DE-Dortmund Westerfilder Straße, 51.548117, 7.381117
 Innogy DE-Drensteinfurt Bahnhofsplatz, 51.799467, 7.733983
-Innogy DE-Duisburg, 51.484186, 6.763764
 Innogy DE-Elsdorf, 50.915, 6.591111
 Innogy DE-Erwitte Westerntor, 51.63079, 8.360218
 Innogy DE-Essen Altenessener Str., 51.466267, 7.013612
@@ -6580,7 +6390,6 @@ Innogy DE-Essen Kruppstraße, 51.449093, 7.009079
 Innogy DE-Essen Langemarckstraße, 51.471665, 7.052847
 Innogy DE-Essen Limbeckerplatz, 51.455833, 7.006111
 Innogy DE-Essen Pferdemarkt, 51.460517, 7.013352
-Innogy DE-Essen Pferdemarkt, 51.460996, 7.014705
 Innogy DE-Essen Rosastraße, 51.437257, 7.005947
 Innogy DE-Essen Schützenbahn, 51.463537, 7.016784
 Innogy DE-Essen Segerothstraße, 51.464465, 7.001866
@@ -6589,7 +6398,6 @@ Innogy DE-Essen Zweigertstraße, 51.436525, 6.998903
 Innogy DE-Flammersfeld Rheinstraße, 50.646153, 7.523277
 Innogy DE-Fleringen Gewerbegebiet, 50.20975, 6.4904
 Innogy DE-Frankfurt am Main, 50.112730, 8.652925
-Innogy DE-Fürholzen West, 48.33747, 11.6081
 Innogy DE-Geldern Südwall, 51.516155, 6.322532
 Innogy DE-Goldbach Sachsenhausen, 49.997901, 9.181043
 Innogy DE-Grevenbroich Elfgener Dorfstraße, 51.083806, 6.553237
@@ -6599,7 +6407,6 @@ Innogy DE-Hattingen Augustastr., 51.399347, 7.186377
 Innogy DE-Hattingen Roonstraße /, 51.40115, 7.185217
 Innogy DE-Hemmingen , 48.86795, 9.041447
 Innogy DE-Horhausen , 50.589107, 7.529869
-Innogy DE-Hunsrück Ost, 49.963783, 7.768701
 Innogy DE-Hösbach Jahnstraße, 50.007214, 9.205869
 Innogy DE-Hückeswagen Auf'm Schloß, 51.150588, 7.341565
 Innogy DE-Hückeswagen Rader Straße, 51.153701, 7.341464
@@ -6614,7 +6421,6 @@ Innogy DE-Königsbrunn Alter Postweg, 48.270564, 10.884767
 Innogy DE-Königsforst Ost, 50.899387, 7.152103, 7
 Innogy DE-Kürten Odenthaler Straße, 51.040355, 7.207632
 Innogy DE-Lauingen Rudolf-Diesel-Ring, 48.576725, 10.447875
-Innogy DE-Leipheim, 48.437494, 10.213398
 Innogy DE-Leipzig Porschestr. 1 Bau, 51.405773, 12.295955
 Innogy DE-Ludwigsburg , 48.892726476075, 9.1709412380939
 Innogy DE-Ludwigsfelde Zum Röthepfuhl 1, 52.298889, 13.281667
@@ -6628,7 +6434,6 @@ Innogy DE-Mettmann Düsseldorfer Straße, 51.252, 6.9716
 Innogy DE-Michendorf Zum Weiher, 52.283611, 13.028056
 Innogy DE-Möhnesee Hauptstraße, 51.496778, 8.12878
 Innogy DE-Mülheim an der Ruhr Mellinghofer Strasse, 51.449975, 6.883106
-Innogy DE-Münsterland Ost, 51.942185, 7.551096
 Innogy DE-Münsterland West, 51.945622, 7.547827
 Innogy DE-Naumburg enviaM, 51.143017,11.824768
 Innogy DE-Neuenkirchen Alte Poststr., 52.418583, 7.83615
@@ -6646,7 +6451,6 @@ Innogy DE-Reichenbach Marienstraße, 50.621111, 12.298889
 Innogy DE-Reichenbach Roßplatz, 50.620556, 12.302222
 Innogy DE-Rhede Gildekamp, 51.840246, 6.69537
 Innogy DE-Ruderatshofen Am, 47.8032, 10.55061
-Innogy DE-Ruraue West, 50.929795, 6.337327
 Innogy DE-Sachsenheim Porscheplatz, 48.952045, 9.043545
 Innogy DE-Sankt Augustin Einsteinstraße, 50.791794, 7.178682
 Innogy DE-Schongau An der Fronveste, 47.815037, 10.897106
@@ -6669,7 +6473,6 @@ Innogy DE-Stuttgart-Zuffenhausen Lorenzstr., 48.833486185398, 9.1490431159086
 Innogy DE-Thannhausen Edmund-Zimmermann-Straße, 48.28195, 10.4707
 Innogy DE-Timmendorfer Strand Strandallee, 53.998729, 10.779577
 Innogy DE-Tor1 NORD , 51.410888174102, 12.294660999912
-Innogy DE-Tornesch Pendlerparkplatz, 53.718479, 9.759092, 15
 Innogy DE-Treuen, 50.549113, 12.286336
 Innogy DE-Unkel Kamener, 50.598541, 7.218679
 Innogy DE-Unna Heinrich-Hertz-Straße, 51.535701, 7.727683
@@ -6687,15 +6490,7 @@ Innogy DE-Wolfenbüttel Am Wasserwerk, 52.149172, 10.542817
 Innogy DE-Wolfenbüttel Salzdahlumer Straße, 52.176896, 10.547561
 Innogy DE-Worms EWR AG, 49.630936, 8.356603
 
-Familia DE-Hamburg, 53.608366, 10.044162
-Familia DE-Osterholz-Scharmbeck, 53.232695, 8.754733
-Familia DE-Reihenfeld, 53.822247, 10.502483
-Familia DE-Tarp, 54.669585, 9.395309
-Familia DE-Quickborn, 53.743005, 9.940652
 
-Fortum NO-Alta, 69.966743, 23.268569
-Fortum NO-Bøde Esso Rønvik, 67.293538, 14.407496
-Fortum NO-Sortland, 68.704914, 15.414759
 
 Globus DE-Forchheim Willy-Brandt-Allee 1, 49.706939, 11.070387, 20
 
@@ -7041,9 +6836,7 @@ Ladeverbund+ DE-Tauberbischofsheim, 49.630349,9.666165
 Ladeverbund+ DE-Wilhermsdorf, 49.481100,10.716472
 
 
-LEW DE-Deffingen, 48.433701, 10.292805, 10
 LEW DE-Friedberg Bäckerei Scharold, 48.4064614, 10.952062, 10
-LEW DE-Friedberg McDonald´s, 48.4073617, 10.952510, 10
 LEW DE-Jengen, 48.0034128, 10.721623
 LEW DE-Krumbach, 48.2450945, 10.3616606, 10
 LEW DE-Pfaffenhausen, 48.120746, 10.457604
@@ -7293,7 +7086,6 @@ Lidl DE-Berlin-Charlottenburg-Wilmersdorf Gervinusstr. 30, 52.502652, 13.297872
 Lidl DE-Berlin-Charlottenburg-Wilmersdorf Lise-Meitner-Str. 6, 52.527607, 13.306774
 Lidl DE-Berlin-Friedrichshain Markgrafendamm 25C, 52.500488888889, 13.465565222222
 Lidl DE-Berlin-Friedrichshain-Kreuzberg Zeughofstr. 23A, 52.501165, 13.435445
-Lidl DE-Berlin-Lichtenberg-HSH Einbecker Str. 59, 52.508847, 13.506596
 Lidl DE-Berlin-Lichtenberg-HSH Ontarioseestr. 17, 52.49477, 13.523194
 Lidl DE-Berlin-Lichtenberg-HsH Indira-Gandhi-Str. 101, 52.546526, 13.468823
 Lidl DE-Berlin-Marzahn-Hellersdorf Havemannstraße 1, 52.56976, 13.569398
@@ -7303,10 +7095,8 @@ Lidl DE-Berlin-Mitte Prinzenallee 75-77, 52.555014, 13.383301
 Lidl DE-Berlin-Mitte Provinzstr. 30, 52.565539, 13.378414
 Lidl DE-Berlin-Mitte Quitzowstr. 23, 52.536459, 13.352354
 Lidl DE-Berlin-Mitte Reinickendorfer Str. 41/Wiesenstr. 31, 52.549263, 13.369008
-Lidl DE-Berlin-Neukölln Buckower Damm 194, 52.426465, 13.435053
 Lidl DE-Berlin-Neukölln Donaustr. 96, 52.481056, 13.438636
 Lidl DE-Berlin-Neukölln Maybachufer 32-33, 52.49228, 13.431449
-Lidl DE-Berlin-Neukölln Sonnenallee 192, 52.475516, 13.452033
 Lidl DE-Berlin-Neukölln Späthstr. 162, 52.452793, 13.453153
 Lidl DE-Berlin-Pankow Bornholmer Str. 65, 52.554356, 13.400624
 Lidl DE-Berlin-Pankow Eldenaer Str. 34A, 52.520388, 13.467982
@@ -7317,16 +7107,12 @@ Lidl DE-Berlin-Pankow Pistoriusstr. 66-67, 52.556133, 13.437312
 Lidl DE-Berlin-Pankow Prenzlauer Promenade 65-67, 52.567604, 13.427927
 Lidl DE-Berlin-Pankow Roelckestraße 172, 52.550422, 13.440979
 Lidl DE-Berlin-Reinickendorf Marktstr. 39-42, 52.561726, 13.364862
-Lidl DE-Berlin-Reinickendorf Quickborner Str. 66-70, 52.603383, 13.367485
 Lidl DE-Berlin-Reinickendorf Roedernallee 49-50, 52.586241, 13.341494
 Lidl DE-Berlin-Reinickendorf Waldstraße 19, 52.576723, 13.325784
-Lidl DE-Berlin-Spandau Nonnendammallee 175, 52.539611, 13.233154
 Lidl DE-Berlin-Spandau-Ruhleben Charlottenburger Chaussee 18, 52.526419, 13.24057
 Lidl DE-Berlin-Steglitz-Zehlendorf Bergstraße 86, 52.458434, 13.330018
 Lidl DE-Berlin-Steglitz-Zehlendorf Clayallee 278, 52.441865, 13.265425
-Lidl DE-Berlin-Steglitz-Zehlendorf Steglitzer Damm 95, 52.449192, 13.354091
 Lidl DE-Berlin-Tempelhof-Schöneberg Hauptstr. 122, 52.483229, 13.350931
-Lidl DE-Berlin-Treptow-Köpenick Kiefholzstr. 386, 52.484138, 13.461703
 Lidl DE-Bernsdorf Am Ankerglasplatz 8, 51.375737, 14.071558
 Lidl DE-Besigheim,48.9999253,9.1450107
 Lidl DE-Bielefeld Babenhauser Straße 18, 52.059245, 8.516981
@@ -7408,8 +7194,6 @@ Lidl DE-Erftstadt Herriger Straße 29, 50.800165, 6.760744
 Lidl DE-Erfurt Eislebener Straße 4, 50.991671, 11.028386
 Lidl DE-Eschborn, 50.150624,8.548813, 20
 Lidl DE-Eschborn,50.1406572,8.582645
-Lidl DE-Eschborn/Taunus Ginnheimer Straße 10, 50.140613005203, 8.5825834072842
-Lidl DE-Eschborn/Taunus Ginnheimer Straße 10, 50.140991387842, 8.5822332694471
 Lidl DE-Eschweiler Auerbachstraße 17, 50.823205, 6.250705
 Lidl DE-Eschweiler Dürener Straße 278, 50.818731, 6.288371
 Lidl DE-Essen Gladbecker Straße 413, 51.48758, 6.997351
@@ -7433,7 +7217,6 @@ Lidl DE-Frankfurt/Main-Preungesheim August-Schanz-Straße 60-64, 50.162091, 8.68
 Lidl DE-Frechen Dr.-Gottfried-Cremer-Allee 22, 50.90932, 6.825172
 Lidl DE-Frechen, 50.923133,6.817081
 Lidl DE-Freiburg im Breisgau,47.986351,7.8342237
-Lidl DE-Freiburg-Wiehre Konrad-Goldmann-Str. 3, 47.986466, 7.834654
 Lidl DE-Friedland Neubrandenburger Straße 8c, 53.66381, 13.5456
 Lidl DE-Friedrichroda Bahnhofstraße 38, 50.860683, 10.576783
 Lidl DE-Friedrichsdorf/Taunus Cheshamer Str. 2, 50.25714, 8.648804
@@ -7512,7 +7295,6 @@ Lidl DE-Hoyerswerda Schulstr. 2a, 51.437975, 14.237915
 Lidl DE-Huerth, 50.89371, 6.903387
 Lidl DE-Hönow Mahlsdorfer Str. 82, 52.53978, 13.638347
 Lidl DE-Höxter Lütmarser Straße 76, 51.773981, 9.360177
-Lidl DE-Hürth-Efferen Luxemburger Str. 80, 50.893599, 6.90362
 Lidl DE-Ibbenbüren Osnabrücker Straße 97, 52.289117, 7.72726
 Lidl DE-Idstein,50.2288999,8.2646874
 Lidl DE-Illingen Hofäckerstraße 3, 48.954131, 8.912032
@@ -7525,7 +7307,6 @@ Lidl DE-Jettingen-Scheppach Messerschmittstr. 3, 48.40859, 10.435209
 Lidl DE-Kaiserslautern Kurt-Schumacher-Straße,49.4229881,7.7484161
 Lidl DE-Kamenz Fichtestr. 2, 51.272709, 14.105661
 Lidl DE-Karlsruhe An der Trift,49.0443966,8.3939765
-Lidl DE-Karlsruhe, 49.0446, 8.393927
 Lidl DE-Kassel Kohlenstraße 75, 51.308664, 9.458531
 Lidl DE-Kassel-Unterneustadt Hafenstr. 5, 51.314083, 9.510045
 Lidl DE-Kaufbeuren, 47.8752442, 10.627542
@@ -7552,7 +7333,6 @@ Lidl DE-Köln Dieselstraße 1-3, 50.946268, 6.841452
 Lidl DE-Köln Friedrich-Naumann-Straße 1, 50.899788, 7.075403
 Lidl DE-Köln Karlsruher Str. 21, 50.950515, 7.001184
 Lidl DE-Köln Leyendeckerstraße 2A, 50.95107, 6.90811
-Lidl DE-Köln Leyendeckerstraße 2A, 50.951533, 6.907568
 Lidl DE-Köln Neustadt Süd Bonner Wall 114-116, 50.918233, 6.952414
 Lidl DE-Köln Sebastianstraße 28-32, 50.983404, 6.962064
 Lidl DE-Köln Waffenschmidtstraße 9, 51.002919, 6.873933
@@ -7607,7 +7387,6 @@ Lidl DE-Mechernich Feytalstr. 19, 50.59117, 6.665688
 Lidl DE-Meerane,50.8432676,12.4446721
 Lidl DE-Meitingen-Herbertshofen Ulrichstr. 24, 48.522368, 10.857693
 Lidl DE-Meldorf,54.096076,9.065504
-Lidl DE-Melle Industriestraße 3, 52.193194, 8.353461
 Lidl DE-Melle Spenger Straße 8, 52.199756, 8.454473
 Lidl DE-Menden-Lendringsen Zum Eisenwerk 3, 51.417774, 7.827445
 Lidl DE-Minden Königstraße 170 a, 52.291945, 8.884335
@@ -7661,7 +7440,6 @@ Lidl DE-Offenau,49.2390735,9.1674555
 Lidl DE-Oldenburg-Donnerschwee Wehdestraße 10, 53.15044, 8.238054
 Lidl DE-Oldenburg-Wechloy Ammerländer Heerstraße 272, 53.156808, 8.170312
 Lidl DE-Oranienburg Berliner Straße 49, 52.74822, 13.236639
-Lidl DE-Oschersleben,52.0288961,11.2476357
 Lidl DE-Osnabrück Hannoversche Straße 19, 52.265123, 8.065501
 Lidl DE-Osnabrück Hans-Wunderlich-Straße 2, 52.267027, 8.001444
 Lidl DE-Osnabrück-Dodesheide Mönkedieckstraße 11-13, 52.299187, 8.061235
@@ -7731,7 +7509,6 @@ Lidl DE-Senden Bulderner Straße 8, 51.857431, 7.480552
 Lidl DE-Senden, 48.333704, 10.039548
 Lidl DE-Sindelfingen Leonberger Straße 25, 48.715673, 9.001738
 Lidl DE-Sindelfingen Mahdentalstraße 45, 48.707712, 9.019255
-Lidl DE-Sindelfingen Mahdentalstraße 45, 48.708008, 9.019132
 Lidl DE-Solingen-Wald Nümmener Feld 1, 51.191885, 7.068726
 Lidl DE-Spangenberg Jahnstr. 10-12, 51.115488, 9.662451
 Lidl DE-St. Georgen,48.1230162,8.3382418
@@ -7758,7 +7535,6 @@ Lidl DE-Tönisvorst,51.319875,6.504465,10
 Lidl DE-Türkheim, 48.0557035, 10.63498977
 Lidl DE-Ubstadt-Weiher Ubstadter Straße 34, 49.171632, 8.618013
 Lidl DE-Uelzen,52.9680439,10.5729497
-Lidl DE-Unterwattenbach, 48.614324,12.224013,20
 Lidl DE-Uslar Wiesenstr. 29, 51.660604, 9.629107
 Lidl DE-Vechta Oldenburger Straße 19-21, 52.732969, 8.288206
 Lidl DE-Vellmar Harleshäuser Straße 21, 51.355365, 9.449632
@@ -8537,7 +8313,6 @@ Porsche DE-Wuppertal Porschestraße, 51.3053, 7.25279
 
 Recharge FI-Sodankylä, 67.431695,26.57509
 
-REWE DE-Bremen, 53.136455, 8.739926
 
 schneller-strom-tanken DE-Ehingen, 48.284649, 9.721507
 schneller-strom-tanken DE-Dillingen, 48.579583, 10.496334
@@ -8552,7 +8327,6 @@ ShellRecharge DE-Berg, 50.372, 11.787795
 ShellRecharge DE-Kamen Karree, 51.568119, 7.674458
 ShellRecharge DE-Kirchheim, 50.8342519, 9.5744849, 10
 ShellRecharge DE-Kraftsdorf, 50.8959477, 11.9793605, 5
-ShellRecharge DE-Neu-Ulm, 48.3875766, 10.033160
 ShellRecharge DE-Osnabrück, 52.301747, 7.949302
 ShellRecharge NL-Heerlen, 50.823176, 6.019581, 30
 
@@ -8768,7 +8542,6 @@ TotalEnergies NL-Houten,52.02856801,5.131599354,80
 TotalEnergies NL-Kadoelen,52.41673049,4.912498327,80
 TotalEnergies NL-Kruisberg,50.88671064,5.739580901,80
 TotalEnergies NL-Leiderdorp Aurora,52.16004438,4.554247245,80
-TotalEnergies NL-Lelystad Aalscholver,52.43561752,5.425150192,80
 TotalEnergies NL-Leusden,52.14337952,5.417969669,80
 TotalEnergies NL-Maarheeze,51.32249303,5.593607509,80
 TotalEnergies NL-Marwijk Kooy,52.33474716,4.928431654,80
@@ -8911,44 +8684,32 @@ CZ Praha Cinestar, 50.070897, 14.401644
 CZ Praha Siemens, 50.04811, 14.306508
 
 DE Aachen Quellenhof, 50.781109, 6.090785
-DE Asbach-Bäumenheim Rastpark, 48.67384, 10.825147
 DE Aurich EEZ, 53.496286, 7.494351 
 DE Aurich McDonnald's, 53.471027, 7.46725
 DE Bad Homburg Hessenring, 50.220598, 8.622014
 DE Bad Homburg Horexstraße 28-30, 50.219575, 8.621767
 DE Bad Oldesloe Käthe-Kollwitz-Straße, 53.80728316, 10.3825856
 DE Bad Segeberg EWS-Servicecenter, 53.937808, 10.306605
-DE Berlin Burger King Tempelhof, 52.480339, 13.38459
-DE Berlin Burger King Nahmitzer Damm, 52.409047, 13.370429
 DE Berlin Landesvertretung Niedersachsen, 52.512375, 13.377664
 DE Berlin Südkreuz, 52.475697, 13.364082
-DE Berlin VW Franklinstr., 52.519344, 13.326864
-DE Bertelsdorf Mediamarkt, 50.287221, 10.985319
 DE Bitterfeld-Wolfen envia, 51.624576, 12.307812
 DE Bochum Ruhrpark, 51.494065, 7.28446
 DE Bonn Welschnonnenstraße, 50.740501,7.101638
-DE Bremen Konsul-Smidt-Straße, 53.089439, 8.778173
-DE Brunnthal Hofoldinger Fors, 47.997213, 11.675992, 5
-DE Burgdorf Burger King, 52.45928, 9.992822
 DE Chemnitz HEOS Solar-Carport, 50.802484, 12.852011
 DE Diepholz Verwaltung Stadtwerke, 52.612027,8.374783
 DE Dresden Volkswagen Gläserne Manufaktur, 51.043755, 13.754082
-DE Frankenthal ATU, 49.545836, 8.352769
 DE Frankfurt am Main Hainer Weg 74, 50.096820, 8.693074
 DE Frankfurt am Main Walter-Kolb-Straße 16, 50.105771, 8.685196
 DE Frankfurt am Main Parkhaus Opernturm, 50.116366, 8.67072
 DE Freising Audi Training Center, 48.356508, 11.770911
 DE Garbsen Nord, 52.422338, 9.554441
-DE Garbsen Süd,  52.421211, 9.565703
 DE Garching Parking 19, 48.251597, 11.63772
 DE Gera Siemensstraße 55, 50.9080071, 12.0664679
-DE Germering Hagebaumarkt, 48.141285, 11.371643
 DE Gerstetten Netto, 48.58969, 10.128094
 DE Hamburg Audi Wichert, 53.548799, 10.036493
 DE Hamburg Deichstr., 53.545081, 9.986616
 DE Hameln Bahnhof, 52.101277,9.374308
 DE Hannover A2 Center, 52.42332, 9.835401, 10
-DE Hannover-Lahe, 52.419121, 9.832369, 20
 DE Hannover Finca & Bar Celona, 52.414286, 9.642024, 20
 DE Hannover Messeschnellweg Wes,52.323175,9.814137
 DE Hannover PZH IFA Uni, 52.426875, 9.618212
@@ -8962,25 +8723,17 @@ DE Köln Brügelmannstraße 3, 50.943937, 6.985898
 DE Köln Leonardo Hotel, 50.926801, 6.904346
 DE Lauenburg Am Schüsselteich, 53.3744745, 10.550709, 10
 DE Leipzig Porsche Kundenzentrum, 51.407016, 12.296726, 30
-DE Malsfeld Autohof, 51.086861, 9.485483, 5
-DE Mölln Baumarkt Werkers Welt, 53.622883, 10.682333
 DE Mölln Euronics, 53.640516,10.695056
 DE Mölln VW Riemer, 53.623707, 10.678989
 DE München Messe, 48.136766, 11.691608
-DE Neuwied SWN, 50.431649, 7.457607
 DE Norden WBZ Parkplatz, 53.595065, 7.207816
 DE Nordhausen ELA Ladepark,51.48890770,10.829272
 DE Offenbach Betriebshof OVB, 50.1025541, 8.7788451, 20
 DE Offenbach Honda, 50.08437, 8.839102
-DE Offenburg Shell Tankstelle, 48.464972, 7.931808
-DE Oldenburg Media Markt, 53.161348, 8.172719
-DE Passau Media Markt, 48.574479, 13.414943
 DE Paderborn Westfalen Weser Netz, 51.725959, 8.756923, 5
 DE Rheydt New AG, 51.157497, 6.448055
 DE Riesa Stadtwerke Riesa, 51.301571, 13.309787
-DE Ritterhude HEM, 53.185475,8.706381
 DE Roth Autohaus, 49.245669, 11.119321
-DE Schafstritt Nord, 52.257481, 9.306448
 DE Schönefeld Total, 52.370738, 13.526929
 DE Sandersdorf-Brehna The Style Outlets, 51.555325, 12.192875
 DE Stuttgart Flughafen P12, 48.691895, 9.195894


### PR DESCRIPTION
Some chargers were duplicates so these were filtered out by the following rule:
- delete non-Superchargers with same name (and distance < 500m)
- delete non-Superchargers with different name  (distance < 50m)
- delete Superchargers with same geoposition (distance = 0m)

Manual readjustment afterwards took place to make sure the right ones have been deleted.