### PR TITLE
Add admin submenu styles, make "Dashboards" with multi column

### DIFF
--- a/TeslaLogger/www/admin/abrp.php
+++ b/TeslaLogger/www/admin/abrp.php
@@ -23,7 +23,7 @@ else
 	<link rel="apple-touch-icon" href="img/apple-touch-icon.png">
 	<title><?php t("ABRPTitle"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/adminpanelpassword.php
+++ b/TeslaLogger/www/admin/adminpanelpassword.php
@@ -9,7 +9,7 @@ require_once("tools.php");
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><?php t("Teslalogger Tesla Credentials"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/changelog.php
+++ b/TeslaLogger/www/admin/changelog.php
@@ -10,7 +10,7 @@ require_once("language.php");
 	<link rel="apple-touch-icon" href="img/apple-touch-icon.png">
 	<title>Teslalogger <?php t("Changelog"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/chargingcost.php
+++ b/TeslaLogger/www/admin/chargingcost.php
@@ -9,7 +9,7 @@ require_once("tools.php");
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><?php t("Charging Costs"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/timepicker/1.3.5/jquery.timepicker.min.css">

--- a/TeslaLogger/www/admin/geoadd.php
+++ b/TeslaLogger/www/admin/geoadd.php
@@ -52,7 +52,7 @@ if (isset($id))
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Teslalogger Geofencing V1.1</title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<link rel="stylesheet" href="static/leaflet/1.4.0/leaflet.css" />
    <!-- Make sure you put this AFTER Leaflet's CSS -->
 	<script src="static/leaflet/1.4.0/leaflet.js"></script>

--- a/TeslaLogger/www/admin/geofencing.php
+++ b/TeslaLogger/www/admin/geofencing.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Teslalogger geofencing V1.1</title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<link rel="stylesheet" href="static/leaflet/1.4.0/leaflet.css" />
 	<link rel="stylesheet" href="static/leaflet/1.4.0/MarkerCluster.css" />
   	<link rel="stylesheet" href="static/leaflet/1.4.0/MarkerCluster.Default.css" />

--- a/TeslaLogger/www/admin/index.php
+++ b/TeslaLogger/www/admin/index.php
@@ -27,7 +27,7 @@ else
     <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
     <title>Teslalogger</title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css?v=3">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="static/jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/journeys.php
+++ b/TeslaLogger/www/admin/journeys.php
@@ -9,7 +9,7 @@ require_once("tools.php");
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><?php t("Journeys"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/logfile.php
+++ b/TeslaLogger/www/admin/logfile.php
@@ -32,7 +32,7 @@ if (!isset($_REQUEST["sleep"]) && isset($_REQUEST["lines"]))
     <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
     <title>Teslalogger Logfile</title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/menu.php
+++ b/TeslaLogger/www/admin/menu.php
@@ -87,7 +87,7 @@ function menu($title, $prefix = "")
 					</li>
 					<li id="menu-item-7" class="page_item_has_children">
 						<a href="#"><?php t("Dashboards"); ?></a>
-						<ul class='children'>
+						<ul class='children menu-columns'>
 <?PHP
 						$d = explode("\r\n", $alldashboards);
                         foreach($d as $dl) {

--- a/TeslaLogger/www/admin/ovms.php
+++ b/TeslaLogger/www/admin/ovms.php
@@ -9,7 +9,7 @@ require_once("tools.php");
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Teslalogger <?php t("Tesla Credentials"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="static/jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/password.php
+++ b/TeslaLogger/www/admin/password.php
@@ -12,7 +12,7 @@ $actual_link = (empty($_SERVER['HTTPS']) ? 'http' : 'https') . "://$_SERVER[HTTP
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><?php t("Teslalogger Tesla Credentials"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="static/jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/password_fleet.php
+++ b/TeslaLogger/www/admin/password_fleet.php
@@ -13,7 +13,7 @@ $actual_link = str_replace("&", "%26", $actual_link);
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title><?php t("Teslalogger Tesla Credentials"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="static/jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/password_info.php
+++ b/TeslaLogger/www/admin/password_info.php
@@ -9,7 +9,7 @@ require_once("tools.php");
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Teslalogger <?php t("Tesla Credentials"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/restore.php
+++ b/TeslaLogger/www/admin/restore.php
@@ -8,7 +8,7 @@ require("language.php");
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Teslalogger Restore Database 1.0</title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/restore_upload.php
+++ b/TeslaLogger/www/admin/restore_upload.php
@@ -8,7 +8,7 @@ require("language.php");
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Teslalogger Restore</title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/timepicker/1.3.5/jquery.timepicker.min.css">

--- a/TeslaLogger/www/admin/settings.php
+++ b/TeslaLogger/www/admin/settings.php
@@ -25,7 +25,7 @@ function CarsCombobox($cars, $selected)
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Teslalogger Settings V1.5</title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<link rel="stylesheet" href="static/jquery/timepicker/1.3.5/jquery.timepicker.min.css?v=1.3.5">

--- a/TeslaLogger/www/admin/static/teslalogger_style.css
+++ b/TeslaLogger/www/admin/static/teslalogger_style.css
@@ -3599,6 +3599,18 @@ a.post-thumbnail:hover {
 		right: 8px;
 		top: 20px;
 	}
+
+	.primary-navigation ul li:hover > ul.menu-columns,
+	.primary-navigation ul li.focus > ul.menu-columns {
+		-webkit-column-count: 2;
+		-moz-column-count: 2;
+		-webkit-column-gap: 30px;
+		-moz-column-gap: 30px;
+		column-count: 2;
+		column-gap: 30px;
+		left: auto;
+		right: 0;
+	}
 }
 
 @media screen and (min-width: 810px) {
@@ -4046,6 +4058,13 @@ a.post-thumbnail:hover {
 	.full-width .site-content footer.entry-meta {
 		padding-right: 30px;
 		padding-left: 30px;
+	}
+
+	.primary-navigation ul li:hover > ul.menu-columns,
+	.primary-navigation ul li.focus > ul.menu-columns {
+		-webkit-column-count: 3;
+		-moz-column-count: 3;
+		column-count: 3;
 	}
 }
 

--- a/TeslaLogger/www/admin/superchargebingo.php
+++ b/TeslaLogger/www/admin/superchargebingo.php
@@ -23,7 +23,7 @@ else
     <link rel="apple-touch-icon" href="img/apple-touch-icon.png">
     <title><?php t("SuperChargeBingo"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>

--- a/TeslaLogger/www/admin/wallbox.php
+++ b/TeslaLogger/www/admin/wallbox.php
@@ -9,7 +9,7 @@ require_once("tools.php");
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><?php t("Wallbox"); ?></title>
 	<link rel="stylesheet" href="static/jquery/ui/1.12.1/themes/smoothness/jquery-ui.css">
-	<link rel="stylesheet" href="static/teslalogger_style.css">
+	<link rel="stylesheet" href="static/teslalogger_style.css?v=4">
 	<script src="static/jquery/jquery-1.12.4.js"></script>
 	<script src="static/jquery/ui/1.12.1/jquery-ui.js"></script>
 	<script src="jquery/jquery-migrate-1.4.1.min.js"></script>


### PR DESCRIPTION
The admin dashboards submenu is very long and not optimal styled for bigger screens.
This PR makes it as multi column menu to better fit and reduce scrolling. 

| Before  | After |
| ------------- | ------------- |
|<br><br><img width="1163" alt="Screenshot 2024-02-08 at 21 12 13" src="https://github.com/bassmaster187/TeslaLogger/assets/224665/24bd88c0-07fc-4219-9eb7-9c40709a9778">|<img width="1186" alt="Screenshot 2024-02-08 at 20 51 21" src="https://github.com/bassmaster187/TeslaLogger/assets/224665/0d1cb88f-ed60-496a-82ad-0b2c66d6b84d"> 




