### PR TITLE
Fix URL encoding in HTML Table

### DIFF
--- a/TeslaLogger/WebServer.cs
+++ b/TeslaLogger/WebServer.cs
@@ -2179,7 +2179,7 @@ DROP TABLE chargingstate_bak";
         private static void Debug_TeslaLoggerMessages(HttpListenerRequest request, HttpListenerResponse response)
         {
             response.AddHeader("Content-Type", "text/html; charset=utf-8");
-            WriteString(response, "<html><head></head><body><table border=\"1\">" + string.Concat(Tools.debugBuffer.Select(a => string.Format(Tools.ciEnUS, "<tr><td>{0}&nbsp;{1}</td></tr>", a.Item1, a.Item2))) + "</table></body></html>", true);
+            WriteString(response, "<html><head></head><body><table border=\"1\">" + string.Concat(Tools.debugBuffer.Select(a => string.Format(Tools.ciEnUS, "<tr><td>{0}&nbsp;{1}</td></tr>", a.Item1, HttpUtility.HtmlEncode(a.Item2)))) + "</table></body></html>", true);
         }
 
         private static void Admin_passwortinfo(HttpListenerRequest request, HttpListenerResponse response)


### PR DESCRIPTION
After fix of ContentType header, characters that need entity encoding in HTML, like '<', '>', '&' are not displayed correcly in debug message table. 
This PR fixes the issue by using HtmlEncode()ing every line.