### PR TITLE
Fix null reference crash when setting up new vehicle

### DIFF
--- a/TeslaLogger/WebServer.cs
+++ b/TeslaLogger/WebServer.cs
@@ -1405,7 +1405,7 @@ DROP TABLE chargingstate_bak";
                     o.Add(new KeyValuePair<string, string>(ccVin.ToString(), "VIN: "+ ccVin + " / Name: " + ccDisplayName ));
                 }
 
-                responseString = JsonConvert.SerializeObject(o);)
+                responseString = JsonConvert.SerializeObject(o);
                 contentType = "application/json";
 
             }

--- a/TeslaLogger/WebServer.cs
+++ b/TeslaLogger/WebServer.cs
@@ -1373,13 +1373,39 @@ DROP TABLE chargingstate_bak";
                 for (int x = 0; x < vehicles.Count; x++)
                 {
                     var cc = vehicles[x];
-                    var ccVin = cc["vin"].ToString();
-                    var ccDisplayName = cc["display_name"].ToString();
-                    
+                    if(cc is null)
+                    {
+                        Logfile.Log($"Car #{x} was invalid");
+                        Tools.DebugLog($"Car #{x} was invalid in response \"{resultContent}\"");
+                        continue;
+                    }
+                    var ccVin = cc["vin"]?.ToString();
+                    var ccDisplayName = cc["display_name"]?.ToString();
+                    if (ccVin is null)
+                    {
+                        var resourceType = cc["resource_type"];
+                        if (resourceType == null)
+                        {
+                            Logfile.Log($"Car #{x} has invalid VIN");
+                            Tools.DebugLog($"Car #{x} has invalid VIN in response \"{resultContent}\"");
+                        }
+                        else
+                        {
+                            Logfile.Log($"Car #{x} was not a car, but {resourceType}. Ignoring...");
+                        }
+                        continue;
+                    }
+                    if (ccDisplayName is null)
+                    {
+                        Logfile.Log($"Car #{x} has invalid display name");
+                        Tools.DebugLog($"Car #{x} has invalid display_name in response \"{resultContent}\"");
+                        ccDisplayName = "";
+                    }
+
                     o.Add(new KeyValuePair<string, string>(ccVin.ToString(), "VIN: "+ ccVin + " / Name: " + ccDisplayName ));
                 }
 
-                responseString = JsonConvert.SerializeObject(o);
+                responseString = JsonConvert.SerializeObject(o);)
                 contentType = "application/json";
 
             }


### PR DESCRIPTION
Fix null reference crash, if webhelper's GetAllVehicles() returns non-car data, like  Tesla Wall Connector
