### PR TITLE
Update VIN decoder

### DIFF
--- a/TeslaLogger/Tools.cs
+++ b/TeslaLogger/Tools.cs
@@ -468,10 +468,11 @@ namespace TeslaLogger
                         vin[7] == '6' || // Triple Motor Models S und Model X 2021 Plaid
                         vin[7] == 'B' || // Dual motor - standard Model 3
                         vin[7] == 'C' || // Dual motor - performance Model 3
-                        vin[7] == 'E' ||  // Dual motor - Model Y
-                        vin[7] == 'F' ||  // Dual motor Performance - Model Y
-                        vin[7] == 'K' ||  // Dual motor Standard "Hairpin Windings"
-                        vin[7] == 'L'   // Dual motor Performance "Hairpin Windings"
+                        vin[7] == 'E' || // Dual motor - Model Y
+                        vin[7] == 'F' || // Dual motor Performance - Model Y
+                        vin[7] == 'K' || // Dual motor Standard "Hairpin Windings"
+                        vin[7] == 'L' || // Dual motor Performance "Hairpin Windings"
+                        vin[7] == 'T'    // Dual motor Performance "Highland"
                     )
                 {
                     AWD = true;
@@ -554,6 +555,9 @@ namespace TeslaLogger
                     case 'J':
                     case 'S':
                         motor = "3/Y single";
+                        break;
+                    case 'T':
+                        motor = "3 dual performance highland";
                         break;
                 }
 

--- a/TeslaLogger/WebHelper.cs
+++ b/TeslaLogger/WebHelper.cs
@@ -2697,29 +2697,27 @@ namespace TeslaLogger
             {
                 Tools.VINDecoder(car.Vin, out int year, out _, out bool AWD, out bool MIC, out string battery, out string motor, out _);
 
-                var isPerfomance = car.TrimBadging == "p74d" || motor.Contains("performance");
-
-                if (isPerfomance && year < 2021)
+                if (car.TrimBadging == "p74d" && year < 2021)
                 {
                     WriteCarSettings("0.152", "M3 LR P");
                     return;
                 }
-                if (isPerfomance && year >= 2024)
+                if (car.TrimBadging == "p74d" && year >= 2024)
                 {
                     WriteCarSettings("0.147", "M3 LR P 2024");
                     return;
                 }
-                if (isPerfomance && year >= 2021)
+                if (car.TrimBadging == "p74d" && year >= 2021)
                 {
                     WriteCarSettings("0.158", "M3 LR P 2021");
                     return;
                 }
-                if (isPerfomance && AWD && year < 2021)
+                if (car.TrimBadging == "74d" && AWD && year < 2021)
                 {
                     WriteCarSettings("0.152", "M3 LR");
                     return;
                 }
-                if (isPerfomance && !AWD && year == 2019)
+                if (car.TrimBadging == "74" && !AWD && year == 2019)
                 {
                     WriteCarSettings("0.145", "M3 LR RWD 2019");
                     return;
@@ -2750,6 +2748,11 @@ namespace TeslaLogger
                         else if (motor == "3 dual performance" && year < 2021)
                         {
                             WriteCarSettings("0.158", "M3 LR P");
+                            return;
+                        }
+                        else if (motor == "3 dual performance highland" && year >= 2024)
+                        {
+                            WriteCarSettings("0.147", "M3 LR P 2024");
                             return;
                         }
                         else if (car.DBWhTR >= 0.135 && car.DBWhTR <= 0.142 && AWD)

--- a/TeslaLogger/WebHelper.cs
+++ b/TeslaLogger/WebHelper.cs
@@ -2697,22 +2697,29 @@ namespace TeslaLogger
             {
                 Tools.VINDecoder(car.Vin, out int year, out _, out bool AWD, out bool MIC, out string battery, out string motor, out _);
 
-                if (car.TrimBadging == "p74d" && year < 2021)
+                var isPerfomance = car.TrimBadging == "p74d" || motor.Contains("performance");
+
+                if (isPerfomance && year < 2021)
                 {
                     WriteCarSettings("0.152", "M3 LR P");
                     return;
                 }
-                if (car.TrimBadging == "p74d" && year >= 2021)
+                if (isPerfomance && year >= 2024)
+                {
+                    WriteCarSettings("0.147", "M3 LR P 2024");
+                    return;
+                }
+                if (isPerfomance && year >= 2021)
                 {
                     WriteCarSettings("0.158", "M3 LR P 2021");
                     return;
                 }
-                if (car.TrimBadging == "74d" && AWD && year < 2021)
+                if (isPerfomance && AWD && year < 2021)
                 {
                     WriteCarSettings("0.152", "M3 LR");
                     return;
                 }
-                if (car.TrimBadging == "74" && !AWD && year == 2019)
+                if (isPerfomance && !AWD && year == 2019)
                 {
                     WriteCarSettings("0.145", "M3 LR RWD 2019");
                     return;

--- a/TeslaLogger/WebServer.cs
+++ b/TeslaLogger/WebServer.cs
@@ -1405,7 +1405,7 @@ DROP TABLE chargingstate_bak";
                     o.Add(new KeyValuePair<string, string>(ccVin.ToString(), "VIN: "+ ccVin + " / Name: " + ccDisplayName ));
                 }
 
-                responseString = JsonConvert.SerializeObject(o);)
+                responseString = JsonConvert.SerializeObject(o);
                 contentType = "application/json";
 
             }

--- a/TeslaLogger/WebServer.cs
+++ b/TeslaLogger/WebServer.cs
@@ -1373,13 +1373,39 @@ DROP TABLE chargingstate_bak";
                 for (int x = 0; x < vehicles.Count; x++)
                 {
                     var cc = vehicles[x];
-                    var ccVin = cc["vin"].ToString();
-                    var ccDisplayName = cc["display_name"].ToString();
-                    
+                    if(cc is null)
+                    {
+                        Logfile.Log($"Car #{x} was invalid");
+                        Tools.DebugLog($"Car #{x} was invalid in response \"{resultContent}\"");
+                        continue;
+                    }
+                    var ccVin = cc["vin"]?.ToString();
+                    var ccDisplayName = cc["display_name"]?.ToString();
+                    if (ccVin is null)
+                    {
+                        var resourceType = cc["resource_type"];
+                        if (resourceType == null)
+                        {
+                            Logfile.Log($"Car #{x} has invalid VIN");
+                            Tools.DebugLog($"Car #{x} has invalid VIN in response \"{resultContent}\"");
+                        }
+                        else
+                        {
+                            Logfile.Log($"Car #{x} was not a car, but {resourceType}. Ignoring...");
+                        }
+                        continue;
+                    }
+                    if (ccDisplayName is null)
+                    {
+                        Logfile.Log($"Car #{x} has invalid display name");
+                        Tools.DebugLog($"Car #{x} has invalid display_name in response \"{resultContent}\"");
+                        ccDisplayName = "";
+                    }
+
                     o.Add(new KeyValuePair<string, string>(ccVin.ToString(), "VIN: "+ ccVin + " / Name: " + ccDisplayName ));
                 }
 
-                responseString = JsonConvert.SerializeObject(o);
+                responseString = JsonConvert.SerializeObject(o);)
                 contentType = "application/json";
 
             }

--- a/UnitTestsTeslalogger/UnitTestBase.cs
+++ b/UnitTestsTeslalogger/UnitTestBase.cs
@@ -203,6 +203,26 @@ namespace UnitTestsTeslalogger
         }
 
         [TestMethod]
+        public void Car_M3_LR_P_2024_MIC()
+        {
+            Car c = new Car(0, "", "", 0, "", DateTime.Now, "", "", "", "", "", "", "", null, false);
+            WebHelper wh = c.webhelper;
+
+            //2021 Model 3 LR Performance
+            MemoryCache.Default.Remove("GetAvgMaxRage_0");
+            MemoryCache.Default.Add("GetAvgMaxRage_0", 505, DateTime.Now.AddMinutes(1));
+            wh.car.Vin = "LRW3E7ET7RCXXXXXX";
+            wh.car.CarType = "model3";
+            wh.car.CarSpecialType = "base";
+            wh.car.DBWhTR = 0.147;
+            wh.car.TrimBadging = "p74d";
+            wh.UpdateEfficiency();
+
+            Assert.AreEqual("M3 LR P 2024", wh.car.ModelName);
+            Assert.AreEqual(0.147, wh.car.WhTR);
+        }
+
+        [TestMethod]
         public void Car_M3_LR_P_2021_MIC()
         {
             Car c = new Car(0, "", "", 0, "", DateTime.Now, "", "", "", "", "", "", "", null, false);

--- a/UnitTestsTeslalogger/UnitTestBase.cs
+++ b/UnitTestsTeslalogger/UnitTestBase.cs
@@ -223,6 +223,26 @@ namespace UnitTestsTeslalogger
         }
 
         [TestMethod]
+        public void Car_M3_LR_P_2024_MIC_Without_vehicle_config()
+        {
+            Car c = new Car(0, "", "", 0, "", DateTime.Now, "", "", "", "", "", "", "", null, false);
+            WebHelper wh = c.webhelper;
+
+            //2021 Model 3 LR Performance
+            MemoryCache.Default.Remove("GetAvgMaxRage_0");
+            MemoryCache.Default.Add("GetAvgMaxRage_0", 505, DateTime.Now.AddMinutes(1));
+            wh.car.Vin = "LRW3E7ET7RCXXXXXX";
+            wh.car.CarType = "";
+            wh.car.CarSpecialType = "";
+            wh.car.DBWhTR = 0;
+            wh.car.TrimBadging = "";
+            wh.UpdateEfficiency();
+
+            Assert.AreEqual("M3 LR P 2024", wh.car.ModelName);
+            Assert.AreEqual(0.147, wh.car.WhTR);
+        }
+
+        [TestMethod]
         public void Car_M3_LR_P_2021_MIC()
         {
             Car c = new Car(0, "", "", 0, "", DateTime.Now, "", "", "", "", "", "", "", null, false);


### PR DESCRIPTION
Update VIN decoder to correctly decode Model 3 Performance Highland (M3PH).
Also fix WebHelper.UpdateEfficiency incorrecly identifying M3PH as M3 SR+