### PR TITLE
Fix Inactive

### DIFF
--- a/TeslaLogger/Car.cs
+++ b/TeslaLogger/Car.cs
@@ -254,7 +254,10 @@ namespace TeslaLogger
                     this.wheel_type = wheel_type;
                     this.FleetAPI = fleetAPI;
 
-                    var manualTokenRefreshNeeded = TeslaTokenExpire > DateTime.MinValue && TeslaTokenExpire < DateTime.UtcNow.AddHours(-24);
+                    // Despite Tesla's docs (https://developer.tesla.com/docs/fleet-api/authentication/third-party-tokens#refresh-tokens) mention
+                    // a refresh token lifetime of 24h, we observed that refresh tokens can be used up to 3 weeks to get new access tokens
+                    // => replaced AddHours(-24) with AddDays(-21)
+                    var manualTokenRefreshNeeded = TeslaTokenExpire > DateTime.MinValue && TeslaTokenExpire < DateTime.UtcNow.AddDays(-21);
 
                     // if we cannot refresh the token automatically, because the refresh token is expired, treat car as inactive.
                     if (CarInDB > 0 && !manualTokenRefreshNeeded)

--- a/TeslaLogger/Car.cs
+++ b/TeslaLogger/Car.cs
@@ -254,14 +254,17 @@ namespace TeslaLogger
                     this.wheel_type = wheel_type;
                     this.FleetAPI = fleetAPI;
 
-                    if (CarInDB > 0)
+                    var manualTokenRefreshNeeded = TeslaTokenExpire > DateTime.MinValue && TeslaTokenExpire < DateTime.UtcNow.AddHours(-24);
+
+                    // if we cannot refresh the token automatically, because the refresh token is expired, treat car as inactive.
+                    if (CarInDB > 0 && !manualTokenRefreshNeeded)
                     {
                         Allcars.Add(this);
                     }
                     DbHelper = new DBHelper(this);
                     webhelper = new WebHelper(this);
 
-                    if (CarInDB > 0)
+                    if (CarInDB > 0 && !manualTokenRefreshNeeded)
                     {
                         thread = new Thread(Loop)
                         {

--- a/TeslaLogger/DBHelper.cs
+++ b/TeslaLogger/DBHelper.cs
@@ -5822,19 +5822,35 @@ WHERE
             return "";
         }
 
+        public static DataTable GetCarsByTokenAge(bool descending=false)
+        {
+            return GetCars($"tesla_token_expire {(descending?"DESC":"ASC")}");
+        }
+
         public static DataTable GetCars()
+        {
+            return GetCars("id");
+        }
+        
+        private static DataTable GetCars(string orderByCol)
         {
             DataTable dt = new DataTable();
 
+            // defense against SQLInjection
+            if(!Regex.Match(orderByCol "^\w+"$))
+            {
+                orderByCol = "id";
+            }
+
             try
             {
-                using (MySqlDataAdapter da = new MySqlDataAdapter(@"
+                using (MySqlDataAdapter da = new MySqlDataAdapter($@"
 SELECT
     *
 FROM
     cars
 ORDER BY
-    id", DBConnectionstring))
+    {orderByCol}", DBConnectionstring))
                 {
                     _ = SQLTracer.TraceDA(dt, da);
                 }

--- a/TeslaLogger/DBHelper.cs
+++ b/TeslaLogger/DBHelper.cs
@@ -5837,7 +5837,7 @@ WHERE
             DataTable dt = new DataTable();
 
             // defense against SQLInjection
-            if(!Regex.Match(orderByCol "^\w+"$))
+            if(!Regex.IsMatch(orderByCol, @"^\w+$"))
             {
                 orderByCol = "id";
             }

--- a/TeslaLogger/Program.cs
+++ b/TeslaLogger/Program.cs
@@ -214,7 +214,7 @@ namespace TeslaLogger
 
         internal static void GetAllCars()
         {
-            using (DataTable dt = DBHelper.GetCars())
+            using (DataTable dt = DBHelper.GetCarsByTokenAge(true))
             {
                 foreach (DataRow r in dt.Rows)
                 {

--- a/TeslaLogger/WebServer.cs
+++ b/TeslaLogger/WebServer.cs
@@ -505,7 +505,7 @@ namespace TeslaLogger
         {
             int CarID = int.Parse(url.Segments[2]);
             Car car = Car.GetCarByID(CarID);
-            car.telemetry.CloseConnection();
+            car?.telemetry.CloseConnection();
             WriteString(response, @"OK");
         }
 
@@ -513,7 +513,7 @@ namespace TeslaLogger
         {
             int CarID = int.Parse(url.Segments[2]);
             Car car = Car.GetCarByID(CarID);
-            car.telemetry.StartConnection();
+            car?.telemetry.StartConnection();
             WriteString(response, @"OK");
         }
 
@@ -1789,10 +1789,13 @@ DROP TABLE chargingstate_bak";
                 {
                     c = Car.GetCarByID(CarID);
                     Logfile.Log("SuCBingoDev: lat=" + lat.ToString(Tools.ciEnUS) + " lng=" + lng.ToString(Tools.ciEnUS));
-                    _ = Task.Factory.StartNew(() =>
+                    if(c != null)
                     {
-                        _ = c.webhelper.SuperchargeBingoCheckin(lat, lng);
-                    }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                        _ = Task.Factory.StartNew(() =>
+                        {
+                            _ = c.webhelper.SuperchargeBingoCheckin(lat, lng);
+                        }, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+                    }
                 }
 
                 catch (Exception ex)
@@ -2385,6 +2388,12 @@ DROP TABLE chargingstate_bak";
                 {
                     StringBuilder sb = new StringBuilder();
                     c = Car.GetCarByID(CarID);
+
+                    if(c == null)
+                    {
+                        response.StatusCode = (int)HttpStatusCode.NotFound;
+                        WriteString(response, "Car not found");
+                    }
 
                     c.webhelper.lastUpdateEfficiency = DateTime.Now.AddDays(-1);
                     string s = c.webhelper.Wakeup().Result;


### PR DESCRIPTION
This PR fixes the state of the new active checkbox in credentials after commit c25db75

Now, we treat cars with too old tokens as inactive and don't try to use Tesla API, which greatly improves restart performance when inactive cars are present in database.

Note, if token is older than 24h, there is no way to automatically recover, because the refresh token is expired as well. So the user has to enter their credentials again manually.