### PR TITLE
MQTT: Additional check for inactive cars

### DIFF
--- a/TeslaLogger/MQTT.cs
+++ b/TeslaLogger/MQTT.cs
@@ -430,8 +430,9 @@ namespace TeslaLogger
                 foreach (dynamic car in cars)
                 {
                     int id = car["id"];
+                    string inactiveFlag = car["inactive"];
                     var carObj = Car.GetCarByID(id);
-                    if (carObj == null || carObj.GetCurrentState() == Car.TeslaState.Inactive)
+                    if (carObj == null || carObj.GetCurrentState() == Car.TeslaState.Inactive || inactiveFlag == "1")
                     {
                         continue; //skip inactive cars
                     }


### PR DESCRIPTION
This PR adds another check for inactive field of /getallcars response during MQTT startup.
This should avoid messages like "MQTT: CurrentJson Exception: The remote server returned an error: (404) Not Found."