### PR TITLE
Docker compose tiny improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   teslalogger:
     build: docker/teslalogger/.
     restart: always
+    init: true
     volumes:
       - ./TeslaLogger/www:/var/www/html
       - ./TeslaLogger/bin:/etc/teslalogger


### PR DESCRIPTION
## ~Assign names to containers that need to be accessible from the browser~

as discussed offline I dropped this commit to preserve compatibility with existing reverse proxy setups. 

Just in case, a description of what has been here before is in the quotation block below

> Giving containers explicit names makes it much easier to set up a reverse proxy with proper SSL termination. Within the same Docker Compose environment, you can now reference containers by name (e.g., http://teslalogger:5000), enabling a reverse proxy (such as Caddy or Nginx) to:
> 
> - Connect internally to the named container (e.g., teslalogger)
> -  Provide HTTPS encryption on the external-facing side
> This internal name resolution simplifies configuration and helps maintain a clean, secure setup.

## add `init` flag. 

Enabling the [init flag](https://docs.docker.com/reference/compose-file/services/#init) allows the container to handle and forward signals correctly, which drastically speeds up shutdown times. Here’s what changes:

- Before: Stopping the container (docker compose down) could take more than 10 seconds.
- After: With init enabled, the same operation now completes in about 1.4 seconds.

This improvement occurs because the minimal “init” process (PID 1) inside the container properly manages child processes and signals, preventing long shutdown delays.
Bellow is a demonstration. Notice the timer at the right side of the terminal. 

[![asciicast](https://asciinema.org/a/YLKkIB4Yqt8sbjRQCyriTHo3K.svg)](https://asciinema.org/a/YLKkIB4Yqt8sbjRQCyriTHo3K)