### PR TITLE
Enhance charging history service

### DIFF
--- a/TeslaLogger/GetChargingHistoryV2Service.cs
+++ b/TeslaLogger/GetChargingHistoryV2Service.cs
@@ -418,7 +418,8 @@ LIMIT 1
                                     }
                                 }
                                 if (fee.ContainsKey("pricingType")
-                                    && fee["pricingType"].ToString().Equals("PAYMENT")
+                                    && (fee["pricingType"].ToString().Equals("PAYMENT") ||
+                                        fee["pricingType"].ToString().Equals("CREDIT_PARTIAL_PAYMENT"))
                                     && fee.ContainsKey("totalDue")
                                     )
                                 {

--- a/TeslaLogger/GetChargingHistoryV2Service.cs
+++ b/TeslaLogger/GetChargingHistoryV2Service.cs
@@ -158,7 +158,7 @@ INSERT IGNORE INTO teslacharging SET
         {
             Tools.DebugLog($"GetChargingHistoryV2Service.LoadAll(#{car.CarInDB})");
             int resultPage = 1;
-            string result = car.webhelper.GetChargingHistoryV2(resultPage).Result;
+            string result = car.webhelper.GetChargingHistoryV2(car.Vin, resultPage).Result;
             if (result == null || result == "{}" || string.IsNullOrEmpty(result))
             {
                 Tools.DebugLog($"GetChargingHistoryV2Service.LoadAll(#{car.CarInDB}): result == null");
@@ -186,7 +186,7 @@ INSERT IGNORE INTO teslacharging SET
                 resultPage++;
                 Thread.Sleep(2500); // wait a bit
                 Tools.DebugLog($"GetChargingHistoryV2Service.LoadAll(#{car.CarInDB}) resultpage {resultPage}");
-                result = car.webhelper.GetChargingHistoryV2(resultPage).Result;
+                result = car.webhelper.GetChargingHistoryV2(car.Vin, resultPage).Result;
             }
         }
 

--- a/TeslaLogger/WebHelper.cs
+++ b/TeslaLogger/WebHelper.cs
@@ -5211,13 +5211,17 @@ DESC", con))
             return "NULL";
         }
 
-        public async Task<string> GetChargingHistoryV2(int pageNumber = 1)
+
+
+        public async Task<string> GetChargingHistoryV2(int pageNumber = 1) => await GetChargingHistoryV2(null, pageNumber);
+
+        public async Task<string> GetChargingHistoryV2(string vin, int pageNumber = 1)
         {
             string resultContent = "";
             try
             {
                 HttpClient httpclientgetChargingHistoryV2 = GethttpclientgetChargingHistoryV2();
-                using (var request = new HttpRequestMessage(HttpMethod.Get, new Uri($"{apiaddress}api/1/dx/charging/history?pageNo={pageNumber}")))
+                using (var request = new HttpRequestMessage(HttpMethod.Get, new Uri($"{apiaddress}api/1/dx/charging/history?pageNo={pageNumber}{(!string.IsNullOrEmpty(vin)?"&vin="+vin:"")}")))
                 {
                     Tools.DebugLog($"GetChargingHistoryV2 #{car.CarInDB} request: {request.RequestUri}");
                     request.Headers.Add("Authorization", "Bearer " + Tesla_token);


### PR DESCRIPTION
1. Limit API response of call to endpoint charging/history to current vehicle's VIN to improve performance by skipping unnecessary database interactions, e.g. for inactive vehicles or multiple vehicles returned for each car id.
2. Add handling of SuC pricingType "CREDIT_PARTIAL_PAYMENT" to update session price correctly, if part of the session was not billed due to existing SuC credit, e.g. exceeding limit of THG credit during one session or charging more than 30 kWh after taking delivery with SoC < 50%