### PR TITLE
Replaced local builds with official images + healthcheck + moved config to .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,22 @@
+# Timezone for all containers
+TZ=Europe/Berlin
+
+# Base path for TeslaLogger data/config files
+DATA_PATH=./TeslaLogger
+
+# Base path for Docker-related files (Dockerfiles, configs)
+DOCKER_PATH=./docker
+
+# MariaDB credentials
 MYSQL_USER=teslalogger
 MYSQL_PASSWORD=teslalogger
 MYSQL_DATABASE=teslalogger
 MYSQL_ROOT_PASSWORD=teslalogger
 
+# Grafana admin password
 GRAFANA_PASSWORD=teslalogger
+
+# Ports exposed on the host
+TESLALOGGER_PORT=5010
+GRAFANA_PORT=3000
+WEBSERVER_PORT=8888

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,20 @@
-version: "3"
 services:
-
   teslalogger:
-    build: docker/teslalogger/.
+    image: bassmaster187/teslalogger:latest
     restart: always
     volumes:
-      - ./TeslaLogger/www:/var/www/html
-      - ./TeslaLogger/bin:/etc/teslalogger
-      - ./TeslaLogger/GrafanaDashboards/:/var/lib/grafana/dashboards/
-      - ./TeslaLogger/GrafanaPlugins/:/var/lib/grafana/plugins
-      - ./docker/teslalogger/Dockerfile:/tmp/teslalogger-DOCKER
+      - ${DATA_PATH}/www:/var/www/html
+      - ${DATA_PATH}/bin:/etc/teslalogger
+      - ${DATA_PATH}/GrafanaDashboards/:/var/lib/grafana/dashboards/
+      - ${DATA_PATH}/GrafanaPlugins/:/var/lib/grafana/plugins
+      - ${DOCKER_PATH}/teslalogger/Dockerfile:/tmp/teslalogger-DOCKER
       - teslalogger-tmp:/tmp/
     depends_on:
       - database
     environment:
-      - TZ=Europe/Berlin
+      - TZ=${TZ}
     ports:
-      - 5010:5000
+      - ${TESLALOGGER_PORT}:5000
 
   database:
     image: mariadb:10.4.7
@@ -24,46 +22,58 @@ services:
     env_file:
       - .env
     volumes:
-      - ./TeslaLogger/sqlschema.sql:/docker-entrypoint-initdb.d/sqlschema.sql
-      - ./TeslaLogger/mysql:/var/lib/mysql
+      - ${DATA_PATH}/sqlschema.sql:/docker-entrypoint-initdb.d/sqlschema.sql
+      - ${DATA_PATH}/mysql:/var/lib/mysql
     ports:
       - 3306:3306
     environment:
-      - TZ=Europe/Berlin
+      - TZ=${TZ}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   grafana:
     image: grafana/grafana:10.0.1
     restart: always
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=teslalogger
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
       - GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=natel-discrete-panel,pr0ps-trackmap-panel,teslalogger-timeline-panel
-      - TZ=Europe/Berlin
+      - TZ=${TZ}
     ports:
-      - 3000:3000
+      - ${GRAFANA_PORT}:3000
     volumes:
-      - ./TeslaLogger/bin:/etc/teslalogger
-      - ./TeslaLogger/GrafanaDashboards/:/var/lib/grafana/dashboards/
-      - ./TeslaLogger/GrafanaPlugins/:/var/lib/grafana/plugins
-      - ./TeslaLogger/GrafanaDB:/var/lib/grafana/
-      - ./TeslaLogger/GrafanaConfig/datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yml
-      - ./TeslaLogger/GrafanaConfig/sample.yaml:/etc/grafana/provisioning/dashboards/dashboards.yml
+      - ${DATA_PATH}/bin:/etc/teslalogger
+      - ${DATA_PATH}/GrafanaDashboards/:/var/lib/grafana/dashboards/
+      - ${DATA_PATH}/GrafanaPlugins/:/var/lib/grafana/plugins
+      - ${DATA_PATH}/GrafanaDB:/var/lib/grafana/
+      - ${DATA_PATH}/GrafanaConfig/datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yml
+      - ${DATA_PATH}/GrafanaConfig/sample.yaml:/etc/grafana/provisioning/dashboards/dashboards.yml
     depends_on:
-      - database
+      database:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
 
   webserver:
-    build: docker/webserver/.
+    image: bassmaster187/teslalogger-webserver:latest
     restart: always
     volumes:
-      - ./docker/webserver/php.ini:/usr/local/etc/php/php.ini
-      - ./TeslaLogger/www:/var/www/html
-      - ./TeslaLogger/bin:/etc/teslalogger
-      - ./docker/teslalogger/Dockerfile:/tmp/teslalogger-DOCKER
-      - ./TeslaLogger/GrafanaConfig/datasource.yaml:/tmp/datasource-DOCKER
+      - ${DOCKER_PATH}/webserver/php.ini:/usr/local/etc/php/php.ini
+      - ${DATA_PATH}/www:/var/www/html
+      - ${DATA_PATH}/bin:/etc/teslalogger
+      - ${DOCKER_PATH}/teslalogger/Dockerfile:/tmp/teslalogger-DOCKER
+      - ${DATA_PATH}/GrafanaConfig/datasource.yaml:/tmp/datasource-DOCKER
       - teslalogger-tmp:/tmp/
     ports:
-      - 8888:80
+      - ${WEBSERVER_PORT}:80
     environment:
-      - TZ=Europe/Berlin
+      - TZ=${TZ}
 
 volumes:
-    teslalogger-tmp:
+  teslalogger-tmp:


### PR DESCRIPTION
Replaced local builds with official teslalogger and webserver images. Added healthchecks for MariaDB and Grafana. Made timezone, data paths, ports, and passwords configurable via .env for better flexibility.

Note: The `.docker` folder may no longer be needed after switching to official images.