### PR TITLE
Moved compose-configs to .env-file + added healthchecks + restricted watchtower

### DIFF
--- a/.env
+++ b/.env
@@ -2,16 +2,10 @@
 TZ=Europe/Berlin
 
 # Base path for TeslaLogger backup and data files
+#   .                               | Current directory where docker-compose.yml is located
+#   ./subfolder                     | Relative path - subfolder next to docker-compose.yml
+#   /mnt/user/appdata/teslalogger   | Absolute path to data directory
 APPDATA_PATH=.
-
-# MariaDB credentials
-MYSQL_USER=teslalogger
-MYSQL_PASSWORD=teslalogger
-MYSQL_DATABASE=teslalogger
-MYSQL_ROOT_PASSWORD=teslalogger
-
-# Grafana admin password
-GRAFANA_PASSWORD=teslalogger
 
 # Watchtower API token
 WATCHTOWER_ENABLE=true

--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 TZ=Europe/Berlin
 
 # Base path for TeslaLogger backup and data files
-APPDATA_PATH=./TeslaLogger
+APPDATA_PATH=.
 
 # MariaDB credentials
 MYSQL_USER=teslalogger

--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 TZ=Europe/Berlin
 
 # Base path for TeslaLogger backup and data files
-BACKUP_PATH=./TeslaLogger
+APPDATA_PATH=./TeslaLogger
 
 # MariaDB credentials
 MYSQL_USER=teslalogger

--- a/.env
+++ b/.env
@@ -1,6 +1,23 @@
+# Timezone for all containers
+TZ=Europe/Berlin
+
+# Base path for TeslaLogger backup and data files
+BACKUP_PATH=./TeslaLogger
+
+# MariaDB credentials
 MYSQL_USER=teslalogger
 MYSQL_PASSWORD=teslalogger
 MYSQL_DATABASE=teslalogger
 MYSQL_ROOT_PASSWORD=teslalogger
 
+# Grafana admin password
 GRAFANA_PASSWORD=teslalogger
+
+# Watchtower API token
+WATCHTOWER_ENABLE=true
+WATCHTOWER_TOKEN=teslalogger
+
+# Ports exposed on the host
+TESLALOGGER_PORT=5010
+GRAFANA_PORT=3000
+WEBSERVER_PORT=8888

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ TeslaLogger/bin/Debug/net8.0/logfile.zip
 TeslaLogger/bin/Debug/net8.0/nohup.out
 TeslaLogger/copy-bin-to-release(main).cmd
 TeslaLogger/delete-REDIRECTDOCKERTOHOST.cmd
+/mysql
+/invoices

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,10 @@ services:
       - .env
     environment:
       - TZ=${TZ:-Europe/Berlin}
+      - MYSQL_USER=teslalogger
+      - MYSQL_PASSWORD=teslalogger
+      - MYSQL_DATABASE=teslalogger
+      - MYSQL_ROOT_PASSWORD=teslalogger
     volumes:
       - teslalogger-net8-sqlschema:/docker-entrypoint-initdb.d
       - ${APPDATA_PATH:-.}/mysql:/var/lib/mysql
@@ -60,7 +64,7 @@ services:
       - teslalogger-net8-grafanadashboards:/var/lib/grafana/dashboards/
       - teslalogger-net8-grafanaplugins:/var/lib/grafana/plugins/
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+      - GF_SECURITY_ADMIN_PASSWORD=teslalogger
       - TZ=${TZ:-Europe/Berlin}
     ports:
       - ${GRAFANA_PORT:-3000}:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   teslalogger:
     image: bassmaster187/teslalogger:latest
+    container_name: teslalogger-core
     restart: always
     volumes:
       - teslalogger-net8-tmp:/tmp/
@@ -21,6 +22,7 @@ services:
       
   database:
     image: mariadb:10.4.7
+    container_name: teslalogger-db
     restart: always
     env_file:
       - .env
@@ -43,6 +45,7 @@ services:
       
   grafana:
     image: bassmaster187/teslalogger-grafana:latest
+    container_name: teslalogger-grafana
     restart: always
     volumes: 
       - teslalogger-net8-grafanadashboards:/var/lib/grafana/dashboards/
@@ -65,6 +68,7 @@ services:
       
   webserver:
     image: bassmaster187/teslalogger-webserver:latest
+    container_name: teslalogger-webserver
     restart: always
     volumes:
       - teslalogger-net8-tmp:/tmp/
@@ -88,6 +92,7 @@ services:
       
   watchtower:
     image: containrrr/watchtower
+    container_name: teslalogger-watchtower
     restart: always
     volumes:
         - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,6 @@ services:
       - TZ=${TZ:-Europe/Berlin}
     ports:
       - ${TESLALOGGER_PORT:-5010}:5000
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${TESLALOGGER_PORT:-5010}/admin/"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
     labels:
       - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
       
@@ -37,12 +31,12 @@ services:
       - ${BACKUP_PATH}/mysql:/var/lib/mysql
     ports:
       - 3306:3306
-    healthcheck:
-      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
-      start_period: 10s
-      interval: 10s
-      timeout: 5s
-      retries: 3
+    #healthcheck:
+    #  test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+    #  start_period: 10s
+    #  interval: 10s
+    #  timeout: 5s
+    #  retries: 3
     labels:
       - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
       

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,34 +7,47 @@ services:
       - teslalogger-net8-sqlschema:/etc/teslalogger/sqlschema
       - teslalogger-net8-grafanadashboards:/var/lib/grafana/dashboards/
       - teslalogger-net8-grafanaplugins:/var/lib/grafana/plugins/
-      - ./backup:/etc/teslalogger/backup
+      - ${BACKUP_PATH}/backup:/etc/teslalogger/backup
       - teslalogger-net8-data:/etc/teslalogger/data
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     environment:
-      - TZ=Europe/Berlin
+      - TZ=${TZ:-Europe/Berlin}
     ports:
-      - 5010:5000
+      - ${TESLALOGGER_PORT:-5010}:5000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${TESLALOGGER_PORT:-5010}/admin/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     labels:
-      - "com.centurylinklabs.watchtower.enable=true"
-
+      - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
+      
+      
   database:
     image: mariadb:10.4.7
     restart: always
+    env_file:
+      - .env
     environment:
-      - MYSQL_USER=teslalogger
-      - MYSQL_PASSWORD=teslalogger
-      - MYSQL_DATABASE=teslalogger
-      - MYSQL_ROOT_PASSWORD=teslalogger
-      - TZ=Europe/Berlin
+      - TZ=${TZ:-Europe/Berlin}
     volumes:
       - teslalogger-net8-sqlschema:/docker-entrypoint-initdb.d
-      - ./mysql:/var/lib/mysql
+      - ${BACKUP_PATH}/mysql:/var/lib/mysql
     ports:
       - 3306:3306
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     labels:
-      - "com.centurylinklabs.watchtower.enable=true"
-
+      - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
+      
+      
   grafana:
     image: bassmaster187/teslalogger-grafana:latest
     restart: always
@@ -42,15 +55,22 @@ services:
       - teslalogger-net8-grafanadashboards:/var/lib/grafana/dashboards/
       - teslalogger-net8-grafanaplugins:/var/lib/grafana/plugins/
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=teslalogger
-      - TZ=Europe/Berlin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+      - TZ=${TZ:-Europe/Berlin}
     ports:
-      - 3000:3000
+      - ${GRAFANA_PORT:-3000}:3000
     depends_on:
-      - database
+      database:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     labels:
-      - "com.centurylinklabs.watchtower.enable=true"
-
+      - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
+      
+      
   webserver:
     image: bassmaster187/teslalogger-webserver:latest
     restart: always
@@ -61,11 +81,19 @@ services:
       - teslalogger
       - grafana
     ports:
-      - 8888:80
+      - ${WEBSERVER_PORT:-8888}:80
     environment:
-      - TZ=Europe/Berlin
+      - TZ=${TZ:-Europe/Berlin}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     labels:
-      - "com.centurylinklabs.watchtower.enable=true"
+      - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
+      
+      
   watchtower:
     image: containrrr/watchtower
     restart: always
@@ -73,9 +101,10 @@ services:
         - /var/run/docker.sock:/var/run/docker.sock
     command: --debug --http-api-update 
     environment:
-      - WATCHTOWER_HTTP_API_TOKEN=teslalogger
+      - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_TOKEN}
       - WATCHTOWER_LABEL_ENABLE=true
-
+      
+      
 volumes:
     teslalogger-net8-tmp:
     teslalogger-net8-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,7 @@ services:
       - ${BACKUP_PATH}/backup:/etc/teslalogger/backup
       - teslalogger-net8-data:/etc/teslalogger/data
     depends_on:
-      database:
-        condition: service_healthy
+      - database
     environment:
       - TZ=${TZ:-Europe/Berlin}
     ports:
@@ -60,8 +59,7 @@ services:
     ports:
       - ${GRAFANA_PORT:-3000}:3000
     depends_on:
-      database:
-        condition: service_healthy
+      - database
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/health"]
       interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
     ports:
       - ${TESLALOGGER_PORT:-5010}:5000
     labels:
-      - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
+      - com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}
+      - com.centurylinklabs.watchtower.scope=teslalogger-stack
       
       
   database:
@@ -46,7 +47,8 @@ services:
     #  timeout: 5s
     #  retries: 3
     labels:
-      - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
+      - com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}
+      - com.centurylinklabs.watchtower.scope=teslalogger-stack
       
       
   grafana:
@@ -69,7 +71,8 @@ services:
       timeout: 5s
       retries: 3
     labels:
-      - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
+      - com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}
+      - com.centurylinklabs.watchtower.scope=teslalogger-stack
       
       
   webserver:
@@ -93,19 +96,22 @@ services:
       retries: 3
       start_period: 30s
     labels:
-      - "com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}"
+      - com.centurylinklabs.watchtower.enable=${WATCHTOWER_ENABLE:-true}
+      - com.centurylinklabs.watchtower.scope=teslalogger-stack
       
       
+  # watchtower updates label "teslalogger-stack" only
   watchtower:
     image: containrrr/watchtower
     container_name: teslalogger-watchtower
     restart: always
     volumes:
         - /var/run/docker.sock:/var/run/docker.sock
-    command: --debug --http-api-update 
+    command: --debug --http-api-update --scope teslalogger-stack
     environment:
       - WATCHTOWER_HTTP_API_TOKEN=${WATCHTOWER_TOKEN}
       - WATCHTOWER_LABEL_ENABLE=true
+      - WATCHTOWER_SCOPE=teslalogger-stack
       
       
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - teslalogger-net8-sqlschema:/etc/teslalogger/sqlschema
       - teslalogger-net8-grafanadashboards:/var/lib/grafana/dashboards/
       - teslalogger-net8-grafanaplugins:/var/lib/grafana/plugins/
-      - ${APPDATA_PATH:-./TeslaLogger}/backup:/etc/teslalogger/backup
+      - ${APPDATA_PATH:-.}/backup:/etc/teslalogger/backup
+      - ${APPDATA_PATH:-.}/invoices:/etc/teslalogger/Debug/net8.0/tesla_invoices
       - teslalogger-net8-data:/etc/teslalogger/data
     depends_on:
       - database
@@ -37,7 +38,7 @@ services:
       - TZ=${TZ:-Europe/Berlin}
     volumes:
       - teslalogger-net8-sqlschema:/docker-entrypoint-initdb.d
-      - ${APPDATA_PATH:-./TeslaLogger}/mysql:/var/lib/mysql
+      - ${APPDATA_PATH:-.}/mysql:/var/lib/mysql
     #ports:
     #  - 3306:3306      # No need to expose the DB to the public, communication is stack-internal
     #healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,20 @@
+#
+# ++ DO NOT EDIT ++
+# anything in this section!
+# If you want to use other ports or storage locations:
+# Use the .env file!
+#
 services:
   teslalogger:
     image: bassmaster187/teslalogger:latest
-    container_name: teslalogger-core
+    container_name: teslalogger
     restart: always
     volumes:
       - teslalogger-net8-tmp:/tmp/
       - teslalogger-net8-sqlschema:/etc/teslalogger/sqlschema
       - teslalogger-net8-grafanadashboards:/var/lib/grafana/dashboards/
       - teslalogger-net8-grafanaplugins:/var/lib/grafana/plugins/
-      - ${BACKUP_PATH}/backup:/etc/teslalogger/backup
+      - ${APPDATA_PATH:-./TeslaLogger}/backup:/etc/teslalogger/backup
       - teslalogger-net8-data:/etc/teslalogger/data
     depends_on:
       - database
@@ -30,9 +36,9 @@ services:
       - TZ=${TZ:-Europe/Berlin}
     volumes:
       - teslalogger-net8-sqlschema:/docker-entrypoint-initdb.d
-      - ${BACKUP_PATH}/mysql:/var/lib/mysql
-    ports:
-      - 3306:3306
+      - ${APPDATA_PATH:-./TeslaLogger}/mysql:/var/lib/mysql
+    #ports:
+    #  - 3306:3306      # No need to expose the DB to the public, communication is stack-internal
     #healthcheck:
     #  test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
     #  start_period: 10s


### PR DESCRIPTION
Added known healthchecks for MariaDB and Grafana and basic health checks for TeslaLogger and Webserver. Made timezone, data paths, ports, and passwords configurable via .env for better flexibility.

This PR relates to an old, closed PR:
https://github.com/bassmaster187/TeslaLogger/pull/1554