### PR TITLE
Update Geofence.cs

### DIFF
--- a/TeslaLogger/Geofence.cs
+++ b/TeslaLogger/Geofence.cs
@@ -536,7 +536,7 @@ namespace TeslaLogger
                                 continue;
                             }
 
-                            if (max_power > 150 && (!p.name.Contains("Supercharger-V3") || !p.name.Contains("Supercharger-V4")))
+                            if (!p.name.Contains("Supercharger-V3") || !p.name.Contains("Supercharger-V4"))
                             {
                                 continue;
                             }


### PR DESCRIPTION
Removed max_power>150kW restriction for renaming Supercharger locations.
That caused problems if the location name was added to geofence.csv AFTER charging is done and max power > 150 kW