### PR TITLE
Update Geofence.cs

### DIFF
--- a/TeslaLogger/Geofence.cs
+++ b/TeslaLogger/Geofence.cs
@@ -536,7 +536,7 @@ namespace TeslaLogger
                                 continue;
                             }
 
-                            if (max_power > 150 && (!p.name.Contains("Supercharger-V3") || !p.name.Contains("Supercharger-V4")))
+                            if (!p.name.Contains("Supercharger-V3") || !p.name.Contains("Supercharger-V4"))
                             {
                                 continue;
                             }


### PR DESCRIPTION
charging sessions >150kW max Power at Supercharger-V3 or Supercharger-V4 don't get geofence name if the geofence.csv is outdated. removing the condition fixes the issue.