### PR TITLE
Update Geofence.cs

### DIFF
--- a/TeslaLogger/Geofence.cs
+++ b/TeslaLogger/Geofence.cs
@@ -536,10 +536,10 @@ namespace TeslaLogger
                                 continue;
                             }
 
-                            if (max_power > 150 && (!p.name.Contains("Supercharger-V3") || !p.name.Contains("Supercharger-V4")))
+                            /*if (max_power > 150 && (!p.name.Contains("Supercharger-V3") || !p.name.Contains("Supercharger-V4")))
                             {
                                 continue;
-                            }
+                            }*/
                         }
 
                         found++;


### PR DESCRIPTION
charging sessions >150kW max Power at Supercharger-V3 or Supercharger-V4 don't get geofence name if the geofence.csv is outdated or the geofence is in the geofence-private.csv. removing the condition fixes the issue.

examples:
https://teslalogger.de/charging_pos.php?pos=Supercharger-V3%20DE-Reiskirchen -> https://teslalogger.de/charging_pos.php?pos=Supercharger-V4%20DE-Reiskirchen https://teslalogger.de/charging_pos.php?pos=Supercharger%20DE-Herboltzheim -> https://teslalogger.de/charging_pos.php?pos=Supercharger-V4%20DE-Herbolzheim https://teslalogger.de/charging_pos.php?pos=%E2%9A%A1%E2%9A%A1%E2%9A%A1%20Supercharger-V4%20AT-Parndorf -> https://teslalogger.de/charging_pos.php?pos=Supercharger-V4%20AT-Parndorf