### PR TITLE
Update dotnet-desktop.yml because of retired Windows  2019 Server

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         configuration: [Debug]
   
-    runs-on: windows-2019  # For a list of available runner types, refer to
+    runs-on: windows-2022  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:

--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache-buster
+FROM php:apache
 
 # install packages
 RUN apt-get update && \


### PR DESCRIPTION
Windows Server 2019 has been retired. The Windows Server 2019 image has been removed as of 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045