### PR TITLE
fix: Add unit_of_measurement to time_to_full_charge MQTT sensor

### DIFF
--- a/TeslaLogger/MQTTAutoDiscovery.cs
+++ b/TeslaLogger/MQTTAutoDiscovery.cs
@@ -104,6 +104,7 @@ namespace TeslaLogger
             autoDiscovery["time_to_full_charge"]["discovery_active"] = "true";
             autoDiscovery["time_to_full_charge"]["type"] = "sensor";
             autoDiscovery["time_to_full_charge"]["name"] = "Time to full charge";
+            autoDiscovery["time_to_full_charge"]["unit"] = "h";
             autoDiscovery["time_to_full_charge"]["class"] = "duration";
 
             autoDiscovery["car_version"] = new Dictionary<string, string>();


### PR DESCRIPTION
The time_to_full_charge sensor was being published with device_class 'duration' but without a unit_of_measurement, causing Home Assistant to log an error.

This adds 'h' (hours) as the unit_of_measurement to comply with Home Assistant's requirements for duration sensors. The Tesla API returns time_to_full_charge in hours as a decimal value.

Fixes Home Assistant error:
Entity is using native unit of measurement 'None' which is not a valid unit for the device class ('duration')