### PR TITLE
Fix Charge History Bug

### DIFF
--- a/TeslaLogger/TelemetryParser.cs
+++ b/TeslaLogger/TelemetryParser.cs
@@ -103,7 +103,7 @@ namespace TeslaLogger
 
         private bool driving;
         private bool _acCharging;
-        private string lastDetailedChargeState;
+        private string lastDetailedChargeState = "";
 
         internal bool dcCharging
         {
@@ -1796,7 +1796,7 @@ namespace TeslaLogger
                                         Driving = false;
                                     }
 
-                                    if (!acCharging)
+                                    if (!acCharging && lastDetailedChargeState == "")
                                     {
                                         var current = PackCurrent(j, date);
 
@@ -1810,7 +1810,7 @@ namespace TeslaLogger
                                 }
                                 else if (v1 == "Idle")
                                 {
-                                    if (acCharging)
+                                    if (acCharging && lastDetailedChargeState == "")
                                     {
                                         Log("Stop AC Charging ***");
                                         acCharging = false;

--- a/TeslaLogger/TelemetryParser.cs
+++ b/TeslaLogger/TelemetryParser.cs
@@ -843,11 +843,19 @@ namespace TeslaLogger
 
                             await CheckDetailedChargeStateAsync(d);
 
-                            if (IsCharging && DetailedChargeState == "DetailedChargeStateStopped")
+                            if (DetailedChargeState != "DetailedChargeStateCharging")
                             {
-                                Log("Stop Charging by DetailedChargeState");
-                                acCharging = false;
-                                dcCharging = false;
+                                if (acCharging)
+                                {
+                                    Log("Stop AC Charging by DetailedChargeState");
+                                    acCharging = false;
+                                }
+
+                                if (dcCharging)
+                                {
+                                    Log("Stop DC Charging by DetailedChargeState");
+                                    dcCharging = false;
+                                }
                             }
 
                             if (DetailedChargeState.Contains("DetailedChargeStateNoPower") ||


### PR DESCRIPTION
**Issue**
When a Tesla is configured in TeslaLogger using fleet-telemetry over ZMQ and telemetry contains both ChargeState and DetailedChargeState, `TelemetryParser::StartACChargingAsync()` is sometimes not called when AC charging, causing an issue described below. This occurs because `TelemetryParser::handleStatemachineAsync()` (which handles ChargeState) is called before `TelemetryParser::InsertStatesAsync()` (which handles DetailedChargeState), interfering with the logic flow. Current problematic logic chain in `TelemetryParser::handleMessageAsync()` when starting AC charging (skipping unrelated steps):

  1. `TelemetryParser::handleStatemachineAsync()` is called. [If ChargeState is in the telemetry, it was not AC charging before, and PackCurrent is greater than 2, acCharging is set to true](https://github.com/bassmaster187/TeslaLogger/blob/2c279a619848e94da6440f05dd57c1b9c2bf1d33/TeslaLogger/TelemetryParser.cs#L1803-L1808).
  2. Since `IsCharging == (acCharging || dcCharging)`, IsCharging is now true.
  3. A bit later in the same `TelemetryParser::handleMessageAsync()` call, `TelemetryParser::InsertStatesAsync()`, is invoked, which in turn invokes `TelemetryParser::CheckDetailedChargeStateAsync()` when processing DetailedChargeState telemetry. 
  4. `TelemetryParser::CheckDetailedChargeStateAsync()` will do nothing, [as IsCharging is true](https://github.com/bassmaster187/TeslaLogger/blob/2c279a619848e94da6440f05dd57c1b9c2bf1d33/TeslaLogger/TelemetryParser.cs#L877).


**Result of bug**
Since `TelemetryParser::CheckDetailedChargeStateAsync()` does nothing, it will never invoke `TelemetryParser::StartACChargingAsync()`, and therefore `TelemetryParser::InsertFirstChargingAsync()` is never invoked.

As a result, an initial charging row is not inserted into the database when pack current > 2 at the start of a charge. The StartChargingId in the chargingstate table ends up being the last charging ID of the previous session instead of the first ID of this session, which messes up charging history.

**Note:** Some charges are unaffected, as pack current is sometimes <= 2 on the first telemetry check, depending on how slow the ramp-up is. In this case, acCharging is not set to true based on ChargeState, but later with DetailedChargeState in `TelemetryParser::CheckDetailedChargeStateAsync()` as intended. On my 2023 M3 (LFP), the ramp-up is slow like this when the charge is not scheduled (you just plug it in and it charges). When a charge is scheduled on the car for later in the day, the ramp-up is much faster when charging starts, triggering the bug.

**Fix in this PR**
Only set acCharging in `TelemetryParser::handleStatemachineAsync()` if lastDetailedChargeState == "" (ie, telemetry only has ChargeState and not DetailedChargeState). This allows the logic in `TelemetryParser::CheckDetailedChargeStateAsync()` to execute as intended on every charge.

Additionally, this PR tweaks the logic around ending a charge based on DetailedChargeState. I think there's more to do here to ensure the final charging data is committed to the database. I often don't see the actual final percentage recorded as no final charge row is inserted. This is not a new bug for me, but that fix can come later.