### PR TITLE
BF: Ensure Newtonsoft JSON consistently parses timestamps

### DIFF
--- a/TeslaLogger/TelemetryParser.cs
+++ b/TeslaLogger/TelemetryParser.cs
@@ -196,7 +196,12 @@ namespace TeslaLogger
         {
             try
             {
-                dynamic j = JsonConvert.DeserializeObject(resultContent);
+                JsonSerializerSettings serializerSettings = new()
+                {
+                    DateTimeZoneHandling = DateTimeZoneHandling.Local
+                };
+
+                dynamic j = JsonConvert.DeserializeObject(resultContent, serializerSettings);
 
                 if (j.ContainsKey("data"))
                 {


### PR DESCRIPTION
## Issue
In `TelemetryParser::handleMessageAsync()`, `DateTimeZoneHandling` [is not specified when decoding telemetry JSON](https://github.com/bassmaster187/TeslaLogger/blob/c818c5d4d627112b9729452e16c9fd1911a2b7d2/TeslaLogger/TelemetryParser.cs#L199). Per the docs, this means [the default is RoundTripTime](https://www.newtonsoft.com/json/help/html/P_Newtonsoft_Json_JsonSerializerSettings_DateTimeZoneHandling.htm), which is not what we want. We want the DateTime objects created by the parser (specifically, [createdAt](https://github.com/bassmaster187/TeslaLogger/blob/c818c5d4d627112b9729452e16c9fd1911a2b7d2/TeslaLogger/TelemetryParser.cs#L207)) to always have a kind of `DateTimeKind.Local`. Most of the time, this works fine and Newtonsoft produces DateTime objects with `DateTimeKind.Local` - but not always.

Take, for example, these two telemetry lines outputted by my local fleet-telemetry server. Keep in mind my local time is UTC-4:00.

Telemetry Example 1 ("bad"):
```json
 {"data":[{"key":"DCChargingEnergyIn", "value":{"doubleValue":1.9999999552965164}}], "createdAt":"2026-04-02T23:49:18.190024Z", "vin":"REDACTED", "isResend":false}
```

Telemetry Example 2 ("good"):
```json
{"data":[{"key":"EstBatteryRange", "value":{"doubleValue":101.18083253102942}}, {"key":"ChargerVoltage", "value":{"doubleValue":244.76099867373705}}, {"key":"ACChargingEnergyIn", "value":{"doubleValue":2.1228333649660103}}, {"key":"NumModuleTempMin", "value":{"intValue":10}}, {"key":"TimeToFullCharge", "value":{"doubleValue":3.050000499933958}}], "createdAt":"2026-04-02T23:49:50.689564636Z", "vin":"REDACTED", "isResend":false}
```

Now, let's decode the `createdAt` timestamp the same way TelemetryParser does in a little demo program, and analyze the produced DateTime objects in the Visual Studio debugger:

```cs
using Newtonsoft.Json;

string badJson = @"{""data"":[{""key"":""DCChargingEnergyIn"", ""value"":{""doubleValue"":1.9999999552965164}}], ""createdAt"":""2026-04-02T23:49:18.190024Z"", ""vin"":""REDACTED"", ""isResend"":false}";
string goodJson = @"{""data"":[{""key"":""EstBatteryRange"", ""value"":{""doubleValue"":101.18083253102942}}, {""key"":""ChargerVoltage"", ""value"":{""doubleValue"":244.76099867373705}}, {""key"":""ACChargingEnergyIn"", ""value"":{""doubleValue"":2.1228333649660103}}, {""key"":""NumModuleTempMin"", ""value"":{""intValue"":10}}, {""key"":""TimeToFullCharge"", ""value"":{""doubleValue"":3.050000499933958}}], ""createdAt"":""2026-04-02T23:49:50.689564636Z"", ""vin"":""REDACTED"", ""isResend"":false}";

dynamic? badParsed = JsonConvert.DeserializeObject(badJson);
dynamic? goodParsed = JsonConvert.DeserializeObject(goodJson);

DateTime badTime = badParsed["createdAt"];
DateTime goodTime = goodParsed["createdAt"];
```

And now the result:
<img width="1205" height="194" alt="image" src="https://github.com/user-attachments/assets/695eac3a-f00c-49d5-b574-03fc152d1278" />

As you can see, one of the timestamps creates a DateTime in Local time, and the other creates a DateTime in UTC. In my experience, it uses local time the vast majority of the time.

## Result of bug
Because of this, timestamps inserted into tables like `charging`, `TPMS`, `alerts`, and more are sometimes the wrong time, shifted by the number of hours different the server is from UTC. This happens because TeslaLogger directly uses the output DateTime object to write a row in MySQL, and does not check if the object is in local or utc time. This has a multitude of side effects.

Note: Inserts into the `pos` table are unaffected, as the code there does force the timestamp into UTC, then back to local time as you follow the logic flow.

## Fix in the PR
Tell Newtonsoft JSON to [always create DateTime objects in Local time](https://www.newtonsoft.com/json/help/html/t_newtonsoft_json_datetimezonehandling.htm) as expected. Modifying my demo code snippet above in the same way as this PR shows the issue is resolved:

```cs
using Newtonsoft.Json;

string badJson = @"{""data"":[{""key"":""DCChargingEnergyIn"", ""value"":{""doubleValue"":1.9999999552965164}}], ""createdAt"":""2026-04-02T23:49:18.190024Z"", ""vin"":""REDACTED"", ""isResend"":false}";
string goodJson = @"{""data"":[{""key"":""EstBatteryRange"", ""value"":{""doubleValue"":101.18083253102942}}, {""key"":""ChargerVoltage"", ""value"":{""doubleValue"":244.76099867373705}}, {""key"":""ACChargingEnergyIn"", ""value"":{""doubleValue"":2.1228333649660103}}, {""key"":""NumModuleTempMin"", ""value"":{""intValue"":10}}, {""key"":""TimeToFullCharge"", ""value"":{""doubleValue"":3.050000499933958}}], ""createdAt"":""2026-04-02T23:49:50.689564636Z"", ""vin"":""REDACTED"", ""isResend"":false}";

JsonSerializerSettings serializerSettings = new()
{
    DateTimeZoneHandling = DateTimeZoneHandling.Local
};

dynamic? badParsed = JsonConvert.DeserializeObject(badJson, serializerSettings);
dynamic? goodParsed = JsonConvert.DeserializeObject(goodJson, serializerSettings);

DateTime badTime = badParsed["createdAt"];
DateTime goodTime = goodParsed["createdAt"];
```

<img width="1194" height="198" alt="image" src="https://github.com/user-attachments/assets/53fd7c30-428d-4828-82dd-a345e9379440" />
