### PR TITLE
refactor: use DateTimeOffset for Unix timestamp calculations

### DIFF
--- a/TeslaFi-Import/Program.cs
+++ b/TeslaFi-Import/Program.cs
@@ -517,10 +517,7 @@ namespace TeslaFi_Import
 
         public static DateTime UnixToDateTime(long t)
         {
-            DateTime dt = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            dt = dt.AddMilliseconds(t);
-            dt = dt.ToLocalTime();
-            return dt;
+            return DateTimeOffset.FromUnixTimeMilliseconds(t).LocalDateTime;
 
         }
 

--- a/TeslaLogger/CO2.cs
+++ b/TeslaLogger/CO2.cs
@@ -71,7 +71,7 @@ namespace TeslaLogger
 
             Newtonsoft.Json.Linq.JArray unixtimes = j[0]["xAxisValues"];
 
-            long unixTimestamp = (long)(dateTime.ToUniversalTime().Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
+            long unixTimestamp = new DateTimeOffset(dateTime.ToUniversalTime()).ToUnixTimeSeconds();
             unixTimestamp *= 1000;
 
             int ix = 0;
@@ -219,7 +219,7 @@ namespace TeslaLogger
 
             Newtonsoft.Json.Linq.JArray unixtimes = j[0]["xAxisValues"];
 
-            long unixTimestamp = (long)(dateTime.ToUniversalTime().Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
+            long unixTimestamp = new DateTimeOffset(dateTime.ToUniversalTime()).ToUnixTimeSeconds();
             unixTimestamp *= 1000;
 
             int ix = 0;

--- a/TeslaLogger/Car.cs
+++ b/TeslaLogger/Car.cs
@@ -1100,7 +1100,7 @@ namespace TeslaLogger
                                 {
                                     Tools.DebugLog($"charging_state: {charging_state[TeslaAPIState.Key.Value]}");
                                     // check if charging_state value is not older than 1 minute
-                                    long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                                    long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                                     if (long.TryParse(charging_state[TeslaAPIState.Key.ValueLastUpdate].ToString(), out long valueLastUpdate))
                                     {
                                         Tools.DebugLog($"charging_state now {now} vlu {valueLastUpdate} diff {now - valueLastUpdate}");
@@ -1121,7 +1121,7 @@ namespace TeslaLogger
                                 if (GetTeslaAPIState().GetBool("charge_port_door_open", out bool bcharge_port_door_open) && bcharge_port_door_open)
                                 {
                                     //Tools.DebugLog($"charge_port_door_open: {charge_port_door_open[TeslaAPIState.Key.Value]}");
-                                    long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                                    long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                                     // check if charge_port_door_open value True is not older than 1 minute
                                     if (long.TryParse(charge_port_door_open[TeslaAPIState.Key.ValueLastUpdate].ToString(), out long valueLastUpdate))
                                     {

--- a/TeslaLogger/DBHelper.cs
+++ b/TeslaLogger/DBHelper.cs
@@ -4939,7 +4939,7 @@ WHERE
                     if (charging_state[TeslaAPIState.Key.Value].ToString() == "Charging")
                     {
                         // check if charging_state value Charging is not older than 5 minutes
-                        long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                        long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                         if (long.TryParse(charging_state[TeslaAPIState.Key.ValueLastUpdate].ToString(), out long valueLastUpdate))
                         {
                             if (now - valueLastUpdate < 300000)
@@ -5125,10 +5125,7 @@ VALUES(
 
         public static DateTime UnixToDateTime(long t)
         {
-            DateTime dt = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-            dt = dt.AddMilliseconds(t);
-            dt = dt.ToLocalTime();
-            return dt;
+            return DateTimeOffset.FromUnixTimeMilliseconds(t).LocalDateTime;
 
         }
 

--- a/TeslaLogger/TelemetryParser.cs
+++ b/TeslaLogger/TelemetryParser.cs
@@ -1294,7 +1294,7 @@ namespace TeslaLogger
 
         public static long DateTimeToUTC_UnixTimestamp(DateTime d)
         {
-            return (long)(d.ToUniversalTime().Subtract(new DateTime(1970, 1, 1))).TotalSeconds * 1000;
+            return new DateTimeOffset(d.ToUniversalTime()).ToUnixTimeMilliseconds();
         }
 
         void InsertLastLocation(DateTime d, bool loggingPosId = true)

--- a/TeslaLogger/TeslaAPIState.cs
+++ b/TeslaLogger/TeslaAPIState.cs
@@ -222,7 +222,7 @@ namespace TeslaLogger
                         state = storage[name];
                         if (maxage != 0)
                         {
-                            long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                            long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                             if (long.TryParse(storage[name][Key.Timestamp].ToString(), out long ts) && now - ts > maxage)
                             {
                                 return false;
@@ -277,7 +277,7 @@ namespace TeslaLogger
                         {
                             if (maxage != 0)
                             {
-                                long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                                long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                                 if (long.TryParse(storage[name][Key.Timestamp].ToString(), out long ts) && now - ts > maxage)
                                 {
                                     value = false;
@@ -310,7 +310,7 @@ namespace TeslaLogger
                         {
                             if (maxage != 0)
                             {
-                                long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                                long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                                 if (long.TryParse(storage[name][Key.Timestamp].ToString(), out long ts) && now - ts > maxage)
                                 {
                                     value = int.MinValue;
@@ -343,7 +343,7 @@ namespace TeslaLogger
                         {
                             if (maxage != 0)
                             {
-                                long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                                long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                                 if (long.TryParse(storage[name][Key.Timestamp].ToString(), out long ts) && now - ts > maxage)
                                 {
                                     value = double.NaN;
@@ -376,7 +376,7 @@ namespace TeslaLogger
                         {
                             if (maxage != 0)
                             {
-                                long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                                long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                                 if (long.TryParse(storage[name][Key.Timestamp].ToString(), out long ts) && now - ts > maxage)
                                 {
                                     value = string.Empty;
@@ -1536,7 +1536,7 @@ namespace TeslaLogger
                     && long.TryParse(storage[key][Key.Timestamp].ToString(), out long ts) && ts != 0
                     && long.TryParse(storage[key][Key.ValueLastUpdate].ToString(), out long vlu) && vlu != 0)
                 {
-                    long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+                    long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
                     str += string.Concat($"{key} => v:[{storage[key][Key.Value]}] t:{storage[key][Key.Type]} s:{storage[key][Key.Source]} ts:{storage[key][Key.Timestamp]} now:{now} diff:{now - ts}ms vlu:{storage[key][Key.ValueLastUpdate]} now:{now} diff:{now - vlu}ms", Environment.NewLine);
                 }
                 else
@@ -1557,7 +1557,7 @@ namespace TeslaLogger
                     maxTS = (long)((maxTS < (long)storage[property][Key.Timestamp]) ? storage[property][Key.Timestamp] : maxTS);
                 }
             }
-            long now = (long)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
+            long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             return maxTS > 0 ? now - maxTS : 0;
         }
 

--- a/TeslaLogger/Tools.cs
+++ b/TeslaLogger/Tools.cs
@@ -63,7 +63,7 @@ namespace TeslaLogger
 
         public static long ToUnixTime(DateTime dateTime)
         {
-            return (long)(dateTime - new DateTime(1970, 1, 1)).TotalSeconds;
+            return new DateTimeOffset(dateTime).ToUnixTimeSeconds();
         }
 
         public static void DebugLog(MySqlCommand cmd, string prefix = "", [CallerFilePath] string callerFilePath = null, [CallerLineNumber] int callerLineNumber = 0, [CallerMemberName] string callerMemberName = null)

--- a/UnitTestsTeslalogger/UnitTestBase.cs
+++ b/UnitTestsTeslalogger/UnitTestBase.cs
@@ -24,8 +24,7 @@ namespace UnitTestsTeslalogger
             Car c = new Car(0, "", "", 0, "", DateTime.Now, "", "", "", "", "", "", "", null, false);
 
             Tools.SetThreadEnUS();
-            long unixTimestamp = (long)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
-            unixTimestamp *= 1000;
+            long unixTimestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             c.DbHelper.InsertPos(unixTimestamp.ToString(), 48.456691, 10.030241, 0, 0, 1, 0, 0, 0, 0, 0, "0");
             int startid = c.DbHelper.GetMaxPosid(true);
             c.DbHelper.StartDriveState(DateTime.Now);


### PR DESCRIPTION
Replace hardcoded `new DateTime(1970, 1, 1, ...)` with `DateTimeOffset` built-in methods (`ToUnixTimeSeconds`, `ToUnixTimeMilliseconds`, `FromUnixTimeMilliseconds`). Works on Mono and all .NET targets without any polyfill.