### PR TITLE
Fix OpenStreetMap "403 Referer required" tiles on admin maps

### DIFF
--- a/TeslaLogger/www/admin/geoadd.php
+++ b/TeslaLogger/www/admin/geoadd.php
@@ -66,9 +66,10 @@ if (isset($id))
   var map = new L.Map('map', {center: [<?= $lat ?>,<?= $lng ?>], zoom:18});
   // Define layers and add them to the control widget
     L.control.layers({
-      'OpenStreetMap': L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      'OpenStreetMap': L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-        maxZoom: 19
+        maxZoom: 19,
+        referrerPolicy: 'strict-origin-when-cross-origin'
       }).addTo(map), // Add default layer to map
       'OpenTopoMap': L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
         attribution: 'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',

--- a/TeslaLogger/www/admin/geofencing.php
+++ b/TeslaLogger/www/admin/geofencing.php
@@ -84,9 +84,10 @@ require_once("language.php");
   map = new L.Map('map');
   // Define layers and add them to the control widget
     L.control.layers({
-      'OpenStreetMap': L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      'OpenStreetMap': L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-        maxZoom: 19
+        maxZoom: 19,
+        referrerPolicy: 'strict-origin-when-cross-origin'
       }).addTo(map), // Add default layer to map
       'OpenTopoMap': L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
         attribution: 'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',

--- a/TeslaLogger/www/admin/index.php
+++ b/TeslaLogger/www/admin/index.php
@@ -77,9 +77,10 @@ else
 	map = new L.Map('map');
   // Define layers and add them to the control widget
     L.control.layers({
-      'OpenStreetMap': L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      'OpenStreetMap': L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-        maxZoom: 19
+        maxZoom: 19,
+        referrerPolicy: 'strict-origin-when-cross-origin'
       }).addTo(map), // Add default layer to map
       'OpenTopoMap': L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
         attribution: 'Map data: &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',


### PR DESCRIPTION
The default OpenStreetMap layer on the admin maps renders every tile as OSM's "403r Access blocked - Referer is required" placeholder.

OSM now enforces their tile usage policy and rejects tile requests that arrive without an acceptable Referer header (https://wiki.openstreetmap.org/wiki/Referer). The admin maps create the OSM layer with a bare `L.tileLayer` and no `referrerPolicy`, so depending on the page's referrer policy the browser sends no Referer and OSM blocks the request.

This sets `referrerPolicy: 'strict-origin-when-cross-origin'` on the OSM tile layer (the value OSM recommends, and the modern browser default) so the origin is sent as the Referer. It also drops the deprecated `{s}.` subdomain in favour of the bare `tile.openstreetmap.org` host.

Applied to the three admin pages that define an OSM layer: `index.php`, `geoadd.php`, `geofencing.php`. OpenTopoMap and the Esri satellite layer use different tile servers and are unaffected.

Refs:
- https://wiki.openstreetmap.org/wiki/Referer
- https://wiki.openstreetmap.org/wiki/Blocked_tiles

---

AI-assisted contribution

This change was developed with AI-assisted coding using [Claude Code](https://claude.com/claude-code) (Opus 4.8). The model traced the root cause, identified all three affected admin pages, and produced the patch; a human reviewed and verified the diff before opening this PR. Flagging it for transparency so maintainers know how it was authored.