### PR TITLE
Fix SmartEVSE3 energy readings for firmware v3.10.0+

### DIFF
--- a/TeslaLogger/ElectricityMeterSmartEVSE3.cs
+++ b/TeslaLogger/ElectricityMeterSmartEVSE3.cs
@@ -79,7 +79,6 @@ namespace TeslaLogger
 
         public override double? GetUtilityMeterReading_kWh()
         {
-
             string j = null;
             try
             {
@@ -92,7 +91,7 @@ namespace TeslaLogger
 
                 string value = jsonResult["mains_meter"]["import_active_energy"];
 
-                return Double.Parse(value, Tools.ciEnUS);
+                return ConvertImportActiveEnergyTo_kWh(Double.Parse(value, Tools.ciEnUS), GetVersionString(jsonResult));
             }
             catch (Exception ex)
             {
@@ -117,7 +116,7 @@ namespace TeslaLogger
 
                 string value = jsonResult["ev_meter"]["import_active_energy"];
 
-                return Double.Parse(value, Tools.ciEnUS);
+                return ConvertImportActiveEnergyTo_kWh(Double.Parse(value, Tools.ciEnUS), GetVersionString(jsonResult));
             }
             catch (Exception ex)
             {
@@ -163,9 +162,7 @@ namespace TeslaLogger
                 if (jsonResult == null)
                     return null;
 
-                string fwversion = jsonResult["version"];
-
-                return fwversion;
+                return GetVersionString(jsonResult);
             }
             catch (Exception ex)
             {
@@ -176,6 +173,48 @@ namespace TeslaLogger
             }
 
             return "";
+        }
+
+        private static string GetVersionString(dynamic jsonResult)
+        {
+            string fwversion = jsonResult["version"];
+
+            return fwversion;
+        }
+
+        private static double ConvertImportActiveEnergyTo_kWh(double value, string version)
+        {
+            return IsImportActiveEnergyInWh(version) ? value / 1000.0 : value;
+        }
+
+        private static bool IsImportActiveEnergyInWh(string version)
+        {
+            if (string.IsNullOrEmpty(version))
+                return false;
+
+            Version parsedVersion;
+            if (!TryParseFirmwareVersion(version, out parsedVersion))
+                return false;
+
+            return parsedVersion.CompareTo(new Version(3, 10, 0)) >= 0;
+        }
+
+        private static bool TryParseFirmwareVersion(string version, out Version parsedVersion)
+        {
+            parsedVersion = null;
+
+            version = version.Trim();
+            if (version.StartsWith("v", StringComparison.InvariantCultureIgnoreCase))
+                version = version.Substring(1);
+
+            int length = 0;
+            while (length < version.Length && (char.IsDigit(version[length]) || version[length] == '.'))
+            {
+                length++;
+            }
+
+            version = version.Substring(0, length).TrimEnd('.');
+            return Version.TryParse(version, out parsedVersion);
         }
     }
 }

--- a/UnitTestsTeslalogger/UnitTestWallbox.cs
+++ b/UnitTestsTeslalogger/UnitTestWallbox.cs
@@ -154,6 +154,25 @@ namespace UnitTestsTeslalogger
         }
 
         [TestMethod]
+        public void SmartEVSE3_v3_10_0()
+        {
+            var v = new ElectricityMeterSmartEVSE3("", "");
+            v.mockup_status = System.IO.File.ReadAllText(@"..\..\testdata\smartevse3_v3_10_0.txt");
+
+            double? kwh = v.GetVehicleMeterReading_kWh();
+            var charging = v.IsCharging();
+            var utility_meter_kwh = v.GetUtilityMeterReading_kWh();
+            var version = v.GetVersion();
+            string ret = v.ToString();
+            Console.WriteLine(ret);
+
+            Assert.AreEqual(2874.199951, kwh);
+            Assert.AreEqual(true, charging);
+            Assert.AreEqual(3456.98765, utility_meter_kwh);
+            Assert.AreEqual("v3.10.0", version);
+        }
+
+        [TestMethod]
         public void EVCC_Wallbox()
         {
             var v = new ElectricityMeterEVCC("", "Wallbox1");

--- a/UnitTestsTeslalogger/testdata/smartevse3_v3_10_0.txt
+++ b/UnitTestsTeslalogger/testdata/smartevse3_v3_10_0.txt
@@ -1,0 +1,23 @@
+{
+  "version": "v3.10.0",
+  "serialnr": 1234,
+  "mode": "NORMAL",
+  "mode_id": 1,
+  "car_connected": true,
+  "evse": {
+    "state": "Charging",
+    "state_id": 2,
+    "error": "None",
+    "error_id": 0
+  },
+  "ev_meter": {
+    "description": "Eastron3P",
+    "import_active_power": 6.800000191,
+    "import_active_energy": 2874199.951,
+    "export_active_energy": 0
+  },
+  "mains_meter": {
+    "import_active_energy": 3456987.65,
+    "export_active_energy": 0
+  }
+}


### PR DESCRIPTION
Fixes #1745

SmartEVSE firmware v3.10.0 reports import_active_energy values in Wh instead of kWh. Convert vehicle and mains meter readings to kWh for firmware versions >= v3.10.0 while preserving the existing behavior for older versions.

https://github.com/dingo35/SmartEVSE-3.5/releases/tag/v3.10.0

Add a SmartEVSE v3.10.0 test fixture to cover the conversion.

